### PR TITLE
changed camfiber plots to percentile for dynamic ranges

### DIFF
--- a/py/qqa/webpages/camfiber.py
+++ b/py/qqa/webpages/camfiber.py
@@ -45,9 +45,9 @@ def write_camfiber_html(outfile, data, header):
     html_components['INTEG_RAW_FLUX'] = dict(script=script, div=div)
 
     #- Median S/N
-    figB, hfigB = plot_fibers(data, 'MEDIAN_RAW_SNR', 'B', zmin=0, zmax=10)
-    figR, hfigR = plot_fibers(data, 'MEDIAN_RAW_SNR', 'R', zmin=0, zmax=10)
-    figZ, hfigZ = plot_fibers(data, 'MEDIAN_RAW_SNR', 'Z', zmin=0, zmax=10)
+    figB, hfigB = plot_fibers(data, 'MEDIAN_RAW_SNR', 'B', percentile=(0, 95))#zmin=0, zmax=10)
+    figR, hfigR = plot_fibers(data, 'MEDIAN_RAW_SNR', 'R', percentile=(0, 95))#zmin=0, zmax=10)
+    figZ, hfigZ = plot_fibers(data, 'MEDIAN_RAW_SNR', 'Z', percentile=(0, 98))#zmin=0, zmax=10)
     figs = bk.gridplot([[figB, figR, figZ], [hfigB, hfigR, hfigZ]],
                 toolbar_location='right')
 


### PR DESCRIPTION
This branch is changing the Median S/N plot_fibers from having hard cutoff values (which was flooding the plots) to a percentile based dynamic range of values.

Is there a physical reason behind the hard cutoffs of zmin=0, zmax=10 that requires this to be addressed in a different way?
The image below shows that the range of values MEDIAN_RAW_SNR does take on is from roughly 12 to 20, and a little farther for the infrared.
The peak at the end of the histogram is because the last few percentiles are clipped (see fiber.py plot_fibers function)
![image](https://user-images.githubusercontent.com/46800082/58916541-c94f8300-86d8-11e9-851b-357ae1b4ec72.png)