### PR TITLE
refactored all camfiber code to support columndatasource

### DIFF
--- a/py/qqa/plots/camfiber.py
+++ b/py/qqa/plots/camfiber.py
@@ -8,7 +8,6 @@ from astropy.table import Table
 
 import bokeh
 import bokeh.plotting as bk
-from bokeh.embed import components
 
 from ..plots.fiber import plot_fibers
 from ..plots.core import get_colors
@@ -42,19 +41,19 @@ def plot_per_camfiber(cds, attribute, cameras, components_dict, percentiles={},
     '''
     if attribute not in list(cds.data.keys()):
         return
-    
+
     metric = np.array(cds.data.get(attribute), copy=True)
     #- TODO: add customizable clipping (percentiles, zmins, zmaxs)
-    
+
     #- adjusts for outliers on the full scale
     pmin, pmax = np.percentile(metric, (5, 95))
 
 #     metric = np.clip(metric, pmin, pmax)
     hist_x_range = (pmin * 0.99, pmax * 1.01)
-    
+
     figs_list = []
     hfigs_list = []
-    
+
     for i in range(len(cameras)):
         c = cameras[i]
         if not figs_list:
@@ -63,26 +62,23 @@ def plot_per_camfiber(cds, attribute, cameras, components_dict, percentiles={},
         else:
             plate_x_range = figs_list[0].x_range
             plate_y_range = figs_list[0].y_range
-        
+
         if i == (len(cameras) - 1):
             colorbar = True
         else:
             colorbar = False
-        
+
         fig, hfig = plot_fibers(cds, attribute, cam=c, percentile=percentiles.get(c),
-                        zmin=zmins.get(c), zmax=zmaxs.get(c), 
-                        title=titles.get(c, {}).get(attribute), 
-                        tools=tools, tooltips=tooltips, hist_x_range=hist_x_range, 
+                        zmin=zmins.get(c), zmax=zmaxs.get(c),
+                        title=titles.get(c, {}).get(attribute),
+                        tools=tools, tooltips=tooltips, hist_x_range=hist_x_range,
                         plate_x_range=plate_x_range, plate_y_range=plate_y_range,
                         colorbar = colorbar)
-        
+
         figs_list.append(fig)
         hfigs_list.append(hfig)
-    
-    
-    
-    figs = bk.gridplot([figs_list, hfigs_list], toolbar_location='right')
-    script, div = components(figs)
 
-    components_dict[attribute] = dict(script=script, div=div)
 
+
+    gridplot = bk.gridplot([figs_list, hfigs_list], toolbar_location='right')
+    return gridplot

--- a/py/qqa/plots/camfiber.py
+++ b/py/qqa/plots/camfiber.py
@@ -68,9 +68,20 @@ def plot_per_camfiber(cds, attribute, cameras, components_dict, percentiles={},
 
 
 def colors_for_metric(cds, attribute, metric, num_bins=10):
-    #- If the function is here, it provides the same range for the same attribute,
-    #- rather than adjusting per camera
-    #- TODO: document
+    '''
+    Adds the color values corresponding to a metric to the data
+
+    Args:
+        cds : a bokeh ColumnDataSource object of data
+        attribute : a string column name in CDS
+        metric : a numpy array of the data corresponding to 
+            ATTRIBUTE in CDS
+    Options:
+        num_bins : the number of colors from a palette generated
+
+    ***MUTATES ARGUMENT
+    Updates CDS to include a column of colors for a given attribute
+    '''
     try:
         colors = get_colors(metric, palette=palettes.all_palettes['Paired'][num_bins])
     except RuntimeWarning as rw:

--- a/py/qqa/plots/camfiber.py
+++ b/py/qqa/plots/camfiber.py
@@ -47,35 +47,40 @@ def plot_per_camfiber(cds, attribute, cameras, components_dict, percentiles={},
     #- TODO: add customizable clipping (percentiles, zmins, zmaxs)
     
     #- adjusts for outliers on the full scale
-    pmin, pmax = np.percentile(metric, (2.5, 97.5))
-    metric = np.clip(metric, pmin, pmax)
+    pmin, pmax = np.percentile(metric, (5, 95))
 
-    
-    hist_x_range = (min(metric) * 0.99, max(metric) * 1.01)
+#     metric = np.clip(metric, pmin, pmax)
+    hist_x_range = (pmin * 0.99, pmax * 1.01)
     
     figs_list = []
     hfigs_list = []
     
-    for c in cameras:
+    for i in range(len(cameras)):
+        c = cameras[i]
         if not figs_list:
             plate_x_range = bokeh.models.Range1d(-420, 420)
             plate_y_range = bokeh.models.Range1d(-420, 420)
         else:
             plate_x_range = figs_list[0].x_range
             plate_y_range = figs_list[0].y_range
-
-        palette = np.array(bp.RdYlBu[11])
-        mapper = linear_cmap(attribute, palette, low=min(metric), high=max(metric),
-                             nan_color='gray')
-
-        fig, hfig = plot_fibers(cds, attribute, mapper=mapper, cam=c, percentile=percentiles.get(c),
+        
+        if i == (len(cameras) - 1):
+            colorbar = True
+        else:
+            colorbar = False
+        
+        fig, hfig = plot_fibers(cds, attribute, cam=c, percentile=percentiles.get(c),
                         zmin=zmins.get(c), zmax=zmaxs.get(c), 
                         title=titles.get(c, {}).get(attribute), 
                         tools=tools, tooltips=tooltips, hist_x_range=hist_x_range, 
-                        plate_x_range=plate_x_range, plate_y_range=plate_y_range)
-
+                        plate_x_range=plate_x_range, plate_y_range=plate_y_range,
+                        colorbar = colorbar)
+        
         figs_list.append(fig)
         hfigs_list.append(hfig)
+    
+    
+    
     figs = bk.gridplot([figs_list, hfigs_list], toolbar_location='right')
     script, div = components(figs)
 

--- a/py/qqa/plots/camfiber.py
+++ b/py/qqa/plots/camfiber.py
@@ -44,8 +44,6 @@ def plot_per_camfiber(cds, attribute, cameras, components_dict, percentiles={},
     
     metric = np.array(cds.data.get(attribute), copy=True)
     #- TODO: add customizable clipping (percentiles, zmins, zmaxs)    
-    pmin, pmax = np.percentile(metric, (2.5, 97.5))
-    metric = np.clip(metric, pmin, pmax)
     
     hist_x_range = (min(metric) * 0.99, max(metric) * 1.01)
     
@@ -64,7 +62,8 @@ def plot_per_camfiber(cds, attribute, cameras, components_dict, percentiles={},
         fig, hfig = plot_fibers(cds, attribute, cam=c, percentile=percentiles.get(c),
                         zmin=zmins.get(c), zmax=zmaxs.get(c), 
                         title=titles.get(c, {}).get(attribute), tools=tools,
-                        tooltips=tooltips)
+                        tooltips=tooltips, hist_x_range=hist_x_range,
+                        plate_x_range=plate_x_range, plate_y_range=plate_y_range)
 
         figs_list.append(fig)
         hfigs_list.append(hfig)

--- a/py/qqa/plots/camfiber.py
+++ b/py/qqa/plots/camfiber.py
@@ -43,7 +43,10 @@ def plot_per_camfiber(cds, attribute, cameras, components_dict, percentiles={},
         return
     
     metric = np.array(cds.data.get(attribute), copy=True)
-    #- TODO: add customizable clipping (percentiles, zmins, zmaxs)    
+    #- TODO: add customizable clipping (percentiles, zmins, zmaxs)
+    #- adjusts for outliers on the full scale
+    pmin, pmax = np.percentile(metric, (2.5, 97.5))
+    metric = np.clip(metric, pmin, pmax)
     
     hist_x_range = (min(metric) * 0.99, max(metric) * 1.01)
     

--- a/py/qqa/plots/camfiber.py
+++ b/py/qqa/plots/camfiber.py
@@ -11,42 +11,70 @@ import bokeh.plotting as bk
 from bokeh.embed import components
 
 from ..plots.fiber import plot_fibers
+from ..plots.core import get_colors
+import bokeh.palettes as palettes
 
 
-def plot_per_camfiber(data, attribute, cameras, components_dict, percentiles={}, 
-                      zmaxs={}, zmins={}, titles={}):
+def plot_per_camfiber(cds, attribute, cameras, components_dict, percentiles={},
+                      zmaxs={}, zmins={}, titles={}, tools=None, tooltips=None):
     '''
     ARGS:
-        data : 
+        cds : ColumnDataSource of data
         attribute : string corresponding to column name in DATA
         cameras : list of string representing unique camera values
         components_dict : dictionary of html components for rendering
-    
+
     Options:
-        percentiles : dictionary of cameras corresponding to (min,max) 
+        percentiles : dictionary of cameras corresponding to (min,max)
             percentiles to clip data
         zmaxs : dictionary of cameras corresponding to hardcoded max values
             to clip data
         zmins : dictionary of cameras corresponding to hardcoded min values
             to clip data
         titles : dictionary of titles per camera for a group of camfiber plots
-            where key-value pairs represent a camera-attribute plot title 
-    
+            where key-value pairs represent a camera-attribute plot title
+
     ***MUTATES ARGUMENT
     Updates COMPONENTS_DICT to include key-value pairs to the html components
         for camfib attribute plot-bokeh gridplot object
     '''
-    if attribute not in data.dtype.names:
+    if attribute not in list(cds.data.keys()):
         return
+    
+    metric = np.array(cds.data.get(attribute), copy=True)
+    #- TODO: add customizable clipping (percentiles, zmins, zmaxs)    
+    pmin, pmax = np.percentile(metric, (2.5, 97.5))
+    metric = np.clip(metric, pmin, pmax)
+    
+    xrange = (min(metric) * 0.99, max(metric) * 1.01)
 
+    colors_for_metric(cds, attribute, metric)
+    
     figs_list = []
     hfigs_list = []
+    
     for c in cameras:
-        fig, hfig = plot_fibers(data, attribute, cam=c, percentile=percentiles.get(c, None),
-            zmin=zmins.get(c), zmax=zmaxs.get(c), title=titles.get(c, {}).get(attribute))
+        fig, hfig = plot_fibers(cds, attribute, cam=c, percentile=percentiles.get(c),
+                                zmin=zmins.get(c), zmax=zmaxs.get(c), 
+                                title=titles.get(c, {}).get(attribute), tools=tools,
+                                tooltips=tooltips, x_range=xrange)
+
         figs_list.append(fig)
         hfigs_list.append(hfig)
     figs = bk.gridplot([figs_list, hfigs_list], toolbar_location='right')
     script, div = components(figs)
 
     components_dict[attribute] = dict(script=script, div=div)
+
+
+def colors_for_metric(cds, attribute, metric, num_bins=10):
+    #- If the function is here, it provides the same range for the same attribute,
+    #- rather than adjusting per camera
+    #- TODO: document
+    try:
+        colors = get_colors(metric, palette=palettes.all_palettes['Paired'][num_bins])
+    except RuntimeWarning as rw:
+        print(attribute + ' get colors caused a truedivide error from get colors')
+    colname = attribute + '_color'
+
+    cds.add(colors, colname)

--- a/py/qqa/plots/camfiber.py
+++ b/py/qqa/plots/camfiber.py
@@ -68,7 +68,7 @@ def plot_per_camfiber(cds, attribute, cameras, components_dict, percentiles={},
         mapper = linear_cmap(attribute, palette, low=min(metric), high=max(metric),
                              nan_color='gray')
 
-        fig, hfig = plot_fibers(cds, attribute, colors=mapper, cam=c, percentile=percentiles.get(c),
+        fig, hfig = plot_fibers(cds, attribute, mapper=mapper, cam=c, percentile=percentiles.get(c),
                         zmin=zmins.get(c), zmax=zmaxs.get(c), 
                         title=titles.get(c, {}).get(attribute), 
                         tools=tools, tooltips=tooltips, hist_x_range=hist_x_range, 

--- a/py/qqa/plots/camfiber.py
+++ b/py/qqa/plots/camfiber.py
@@ -1,18 +1,14 @@
-"""
-Placeholder: per-camera per-fiber plots
-"""
 import numpy as np
-
 import jinja2
-from astropy.table import Table
-
 import bokeh
+
+from astropy.table import Table
 import bokeh.plotting as bk
+import bokeh.palettes as bp
+from bokeh.transform import linear_cmap
 
 from ..plots.fiber import plot_fibers
 from ..plots.core import get_colors
-import bokeh.palettes as bp
-from bokeh.transform import linear_cmap
 
 
 def plot_per_camfiber(cds, attribute, cameras, components_dict, percentiles={},
@@ -81,4 +77,5 @@ def plot_per_camfiber(cds, attribute, cameras, components_dict, percentiles={},
 
 
     gridplot = bk.gridplot([figs_list, hfigs_list], toolbar_location='right')
+
     return gridplot

--- a/py/qqa/plots/core.py
+++ b/py/qqa/plots/core.py
@@ -1,12 +1,9 @@
-"""
-Placeholder: Core shared routines for plotting
-"""
 import numpy as np
 import bokeh
 import bokeh.plotting as bk
 import bokeh.palettes as palettes
 
-def get_colors(x, palette=palettes.all_palettes['RdYlBu'][11], 
+def get_colors(x, palette=palettes.all_palettes['RdYlBu'][11],
     xmin=None, xmax=None):
     '''
     Returns a palette of colors for an array of values
@@ -35,17 +32,17 @@ def get_colors(x, palette=palettes.all_palettes['RdYlBu'][11],
 def plot_histogram(metric, num_bins=50, width=250, height=80, x_range=None, title=None):
     '''
     Generates a histogram of values from METRIC
-    
+
     Args:
         metric : a numpy array of values to plot
-        
+
     Options:
         palette : a bokeh palette to color the histogram
         num_bins : number of bins for the histogram
         width, height : width and height of figure in pixels
         x_range : range of histogram values
         title : figure title
-    
+
     Returns a Bokeh figure object
     '''
     hfig = bk.figure(width=width, height=height, x_range=x_range)
@@ -54,7 +51,7 @@ def plot_histogram(metric, num_bins=50, width=250, height=80, x_range=None, titl
     #colors = get_colors(centers, palette)
     hfig.quad(top=hist, bottom=0, left=edges[:-1], right=edges[1:], alpha=0.5,
               color='gray')
-    
+
     hfig.xaxis.axis_label = title
     hfig.toolbar_location = None
     hfig.title.text_color = '#ffffff'

--- a/py/qqa/plots/core.py
+++ b/py/qqa/plots/core.py
@@ -7,10 +7,15 @@ import bokeh.plotting as bk
 import bokeh.palettes as palettes
 
 def get_colors(x, palette=palettes.all_palettes['RdBu'][11], 
-	xmin=None, xmax=None):
+    xmin=None, xmax=None):
     '''
-    TODO: document
-    Returns a palette of colors for 
+    Returns a palette of colors for an array of values
+    Supports clipping of this metric to provided min and max values
+    Args:
+        x : an array of values corresponding to a metric to plot
+    Options:
+        palette : a bokeh palette of colors
+        xmin, xmax : cutoffs to clip values in x
     '''
     palette = np.array(palette)
     n = len(palette)
@@ -28,9 +33,8 @@ def get_colors(x, palette=palettes.all_palettes['RdBu'][11],
     return palette[ii]
 
 def plot_histogram(metric, palette=palettes.all_palettes['RdBu'][11], num_bins=50,
-                  width=250, height=80, x_range=None, title=None):
+                  width=250, height=80, x_range=None):
     '''
-    TODO: document
     Generates a histogram of values from METRIC
     
     Args:
@@ -38,10 +42,9 @@ def plot_histogram(metric, palette=palettes.all_palettes['RdBu'][11], num_bins=5
         
     Options:
         palette : a bokeh palette to color the histogram
-        num_bins : 
-        width, height : 
-        x_range : 
-        title : 
+        num_bins : number of bins for the histogram
+        width, height : width and height of figure in pixels
+        x_range : range of histogram values
     
     Returns a Bokeh figure object
     '''

--- a/py/qqa/plots/core.py
+++ b/py/qqa/plots/core.py
@@ -6,7 +6,7 @@ import bokeh
 import bokeh.plotting as bk
 import bokeh.palettes as palettes
 
-def get_colors(x, palette=palettes.all_palettes['RdBu'][11], 
+def get_colors(x, palette=palettes.all_palettes['RdYlBu'][11], 
     xmin=None, xmax=None):
     '''
     Returns a palette of colors for an array of values

--- a/py/qqa/plots/core.py
+++ b/py/qqa/plots/core.py
@@ -32,8 +32,7 @@ def get_colors(x, palette=palettes.all_palettes['RdYlBu'][11],
     ii = (n*(x-xmin) / (xmax-xmin)).astype(int).clip(0,n-1)
     return palette[ii]
 
-def plot_histogram(metric, palette=palettes.all_palettes['RdBu'][11], num_bins=50,
-                  width=250, height=80, x_range=None, title=None):
+def plot_histogram(metric, num_bins=50, width=250, height=80, x_range=None, title=None):
     '''
     Generates a histogram of values from METRIC
     
@@ -51,10 +50,10 @@ def plot_histogram(metric, palette=palettes.all_palettes['RdBu'][11], num_bins=5
     '''
     hfig = bk.figure(width=width, height=height, x_range=x_range)
     hist, edges = np.histogram(metric, density=True, bins=num_bins)
-    centers = 0.5 * (edges[1:] + edges[:-1])
-    colors = get_colors(centers, palette)
-    hfig.quad(top=hist, bottom=0, left=edges[:-1], right=edges[1:], 
-        color=colors, alpha=0.5)
+    #centers = 0.5 * (edges[1:] + edges[:-1])
+    #colors = get_colors(centers, palette)
+    hfig.quad(top=hist, bottom=0, left=edges[:-1], right=edges[1:], alpha=0.5,
+              color='gray')
     
     hfig.xaxis.axis_label = title
     hfig.toolbar_location = None

--- a/py/qqa/plots/core.py
+++ b/py/qqa/plots/core.py
@@ -33,7 +33,7 @@ def get_colors(x, palette=palettes.all_palettes['RdBu'][11],
     return palette[ii]
 
 def plot_histogram(metric, palette=palettes.all_palettes['RdBu'][11], num_bins=50,
-                  width=250, height=80, x_range=None):
+                  width=250, height=80, x_range=None, title=None):
     '''
     Generates a histogram of values from METRIC
     
@@ -45,6 +45,7 @@ def plot_histogram(metric, palette=palettes.all_palettes['RdBu'][11], num_bins=5
         num_bins : number of bins for the histogram
         width, height : width and height of figure in pixels
         x_range : range of histogram values
+        title : figure title
     
     Returns a Bokeh figure object
     '''

--- a/py/qqa/plots/core.py
+++ b/py/qqa/plots/core.py
@@ -1,4 +1,66 @@
 """
 Placeholder: Core shared routines for plotting
 """
+import numpy as np
+import bokeh
+import bokeh.plotting as bk
+import bokeh.palettes as palettes
 
+def get_colors(x, palette=palettes.all_palettes['RdBu'][11], 
+	xmin=None, xmax=None):
+    '''
+    TODO: document
+    Returns a palette of colors for 
+    '''
+    palette = np.array(palette)
+    n = len(palette)
+
+    x = np.asarray(x)
+    if xmin is None:
+        xmin = np.min(x)
+    if xmax is None:
+        xmax = np.max(x)
+
+    x.clip(xmin, xmax)
+    if (xmin == xmax):
+        raise RuntimeWarning
+    ii = (n*(x-xmin) / (xmax-xmin)).astype(int).clip(0,n-1)
+    return palette[ii]
+
+def plot_histogram(metric, palette=palettes.all_palettes['RdBu'][11], num_bins=50,
+                  width=250, height=80, x_range=None, title=None):
+    '''
+    TODO: document
+    Generates a histogram of values from METRIC
+    
+    Args:
+        metric : a numpy array of values to plot
+        
+    Options:
+        palette : a bokeh palette to color the histogram
+        num_bins : 
+        width, height : 
+        x_range : 
+        title : 
+    
+    Returns a Bokeh figure object
+    '''
+    hfig = bk.figure(width=width, height=height, x_range=x_range)
+    hist, edges = np.histogram(metric, density=True, bins=num_bins)
+    centers = 0.5 * (edges[1:] + edges[:-1])
+    colors = get_colors(centers, palette)
+    hfig.quad(top=hist, bottom=0, left=edges[:-1], right=edges[1:], 
+        color=colors, alpha=0.5)
+    
+    hfig.xaxis.axis_label = title
+    hfig.toolbar_location = None
+    hfig.title.text_color = '#ffffff'
+    hfig.yaxis.major_label_text_font_size = '0pt'
+    hfig.xgrid.grid_line_color = None
+    hfig.ygrid.grid_line_color = None
+    hfig.yaxis.major_tick_line_color = None
+    hfig.yaxis.minor_tick_line_color = None
+    hfig.outline_line_color = None
+    hfig.yaxis.axis_line_color = None
+
+    return hfig

--- a/py/qqa/plots/fiber.py
+++ b/py/qqa/plots/fiber.py
@@ -1,110 +1,83 @@
 import numpy as np
-
-from astropy.table import Table, join
 import jinja2
+import desimodel.io
 
 import bokeh
 import bokeh.plotting as bk
 import bokeh.models
 from bokeh.embed import components
+
+from astropy.table import Table, join
 # from bokeh.models.tickers import FixedTicker
 # from bokeh.models.ranges import FactorRange
-
-from bokeh.models import LinearColorMapper, ColorBar # HoverTool, CustomJS, HTMLTemplateFormatter, NumeralTickFormatter
+from bokeh.models import LinearColorMapper, ColorBar, HoverTool #, CustomJS, HTMLTemplateFormatter, NumeralTickFormatter
+from bokeh.models import ColumnDataSource, CDSView, BooleanFilter
 from bokeh.transform import transform
+from bokeh.transform import linear_cmap
+import bokeh.palettes as palettes
+from ..plots.core import get_colors, plot_histogram
 
-import bokeh.palettes
-
-import desimodel.io
-
-def get_colors(x, xmin=None, xmax=None):
-    '''
-    TODO: document
-    TODO: move this into plots.core or similar
-    '''
-    palette = np.array(bokeh.palettes.all_palettes['RdBu'][11])
-    n = len(palette)
-    
-    x = np.asarray(x)
-    if xmin is None:
-        xmin = np.min(x)
-    if xmax is None:
-        xmax = np.max(x)
-
-    x.clip(xmin, xmax)
-    ii = (n*(x-xmin) / (xmax-xmin)).astype(int).clip(0,n-1)
-    return palette[ii]
-
-def plot_fibers(qadata, name, cam=None, width=250, height=270,
-    zmin=None, zmax=None, percentile=None, title=None):
+def plot_fibers(source, name, cam=None, width=250, height=270, zmin=None, 
+                zmax=None, percentile=None, title=None, x_range=None,
+                tools=None, tooltips=None):
     '''TODO: document
     ARGS:
-        qadata :  
-            #- TODO: would it be possible to just make this argument
-            #- an astropy table?
+        source :  ColumnDataSource object
         name : a string data column in qadata
-    
+
     Options:
         cam : string ('B', 'R', 'Z') to specify which camera wavelength
         (zmin,zmax) : hardcoded (min,max) to clip data
         percentile : (min,max) percentiles to clip data
         width, height : width and height of graph in pixels
         title : title for the plot
+        tools : string of supported features for the plot
+        tooltips : hovertool info
 
-    
+
     Generates a focal plane plot with data per fiber color-coded based on its value
     Generates a histogram of NAME values per fiber
     '''
-
-    #- bytes vs. str, what a pain
-    qadata = Table(qadata)
-    qadata['CAM'] = qadata['CAM'].astype(str)
-    
-    #- Filter data to just this camera
-    if cam is not None:
-        ii = (qadata['CAM'] == cam.lower()) | (qadata['CAM'] == cam.upper())
-        qadata = qadata[ii]
-
     #- Focal plane colored scatter plot
-    fig = bk.figure(width=width, height=height, toolbar_location=None, title=title)
+    fig = bk.figure(width=width, height=height, title=title, tools=tools)
+
+    #- Filter data to just this camera
+    booleans_metric = np.array([True if c == cam.lower() or c == cam.upper()
+        else False for c in source.data['CAM']])
+    view_metric = CDSView(source=source, filters=[BooleanFilter(booleans_metric)])
     
-    fiberpos = Table(desimodel.io.load_fiberpos())
-    fiberpos.remove_column('SPECTRO')
+    #- Plot only the fibers which measured the metric
+    s = fig.scatter('X', 'Y', source=source, view=view_metric, color=name+'_color', 
+                    radius=5, alpha=0.7, hover_color='firebrick')
+    #- Add hover tool
+    hover = HoverTool(renderers = [s], tooltips=tooltips)
+    fig.add_tools(hover)
 
-    if len(qadata) > 0:
-        #- Join with fiberpos to know where fibers are on focal plane
-        #- TODO: use input fibermap instead
-        qadata = join(qadata, fiberpos, keys='FIBER')
-
-        metric = np.array(qadata[name], copy=True)
-        if percentile is not None:
-            pmin, pmax = np.percentile(metric, percentile)
-            metric = np.clip(metric, pmin, pmax)
-
-        if zmin is not None or zmax is not None:
-            metric = np.clip(metric, zmin, zmax)
-
-        colors = get_colors(metric)
-        fig.scatter(qadata['X'], qadata['Y'], color=colors, radius=5, alpha=0.7)
-
-    ii = ~np.in1d(fiberpos['FIBER'], qadata['FIBER'])
-    fig.scatter(fiberpos['X'][ii], fiberpos['Y'][ii], color='#DDDDDD', radius=2)
     
+    #- Plot the rest of the fibers
+    fibers_measured = source.data['FIBER'][booleans_metric]
+    ii = ~np.in1d(source.data['FIBER'], fibers_measured)
+    booleans_empty = [fiber in ii for fiber in range(len(source.data))]
+    view_empty = CDSView(source=source, filters=[BooleanFilter(booleans_empty)])    
+    fig.scatter('X', 'Y', source=source, view=view_empty, color='#DDDDDD', radius=2)
+
+    #- Aesthetics: outline the focal plates by camera color, label cameras,
+    #-             style visual attributes of the figure
     fig.x_range = bokeh.models.Range1d(-420, 420)
     fig.y_range = bokeh.models.Range1d(-420, 420)
-    
+
     camcolors = dict(B='steelblue', R='firebrick', Z='gray')
-    
-    if cam is not None:
+
+    if cam:
         color = camcolors[cam.upper()]
         fig.ellipse(x=[0,], y=[0,], width=830, height=830, fill_color=None,
                     line_color=color, line_alpha=0.5, line_width=2)
-    
-    if cam is not None:
+
+    if cam:
         fig.text([-350,], [350,], [cam.upper(),],
             text_color=camcolors[cam.upper()],
             text_align='center', text_baseline='middle')
-    
+
     fig.xgrid.grid_line_color = None
     fig.ygrid.grid_line_color = None
     fig.xaxis.major_tick_line_color = None
@@ -118,26 +91,19 @@ def plot_fibers(qadata, name, cam=None, width=250, height=270,
     fig.yaxis.major_label_text_font_size = '0pt'
 
     #- Histogram of values
-    #- TODO: move basic histogram code into plots.core or similar
+    if any(booleans_metric):
+        metric = np.array(source.data[name], copy=True)[booleans_metric]
+        if percentile:
+            pmin, pmax = np.percentile(metric, percentile)
+            metric = np.clip(metric, pmin, pmax)
+        if zmin or zmax:
+            metric = np.clip(metric, zmin, zmax)
+        palette = np.sort(source.data[name+'_color'][booleans_metric])
+        #palette = palettes.linear_palette(colors, 10)
+    else:
+        palette = palettes.all_palettes['RdBu'][11]
 
-    hfig = bk.figure(width=width, height=80)
-
-    if len(qadata) > 0:
-        hist, edges = np.histogram(metric, density=True, bins=50)
-        centers = 0.5*(edges[1:] + edges[:-1])
-        colors = get_colors(centers)
-        hfig.quad(top=hist, bottom=0, left=edges[:-1], right=edges[1:], color=colors, alpha=0.5)
+    hfig = plot_histogram(metric, palette, title=name, width=width,
+                          x_range=x_range, num_bins=10)
     
-
-    hfig.xaxis.axis_label = name
-    hfig.toolbar_location = None
-    hfig.title.text_color = '#ffffff'
-    hfig.yaxis.major_label_text_font_size = '0pt'
-    hfig.xgrid.grid_line_color = None
-    hfig.ygrid.grid_line_color = None
-    hfig.yaxis.major_tick_line_color = None
-    hfig.yaxis.minor_tick_line_color = None
-    hfig.outline_line_color = None
-    hfig.yaxis.axis_line_color = None
-
     return fig, hfig

--- a/py/qqa/plots/fiber.py
+++ b/py/qqa/plots/fiber.py
@@ -25,7 +25,7 @@ from ..plots.core import get_colors, plot_histogram
 def plot_fibers(source, name, cam=None, width=250, height=270, zmin=None, 
                 zmax=None, percentile=None, title=None, hist_x_range=None,
                 plate_x_range=None, plate_y_range=None, colorbar=False,
-                tools='box_select,reset', tooltips=None):
+                plot_hist=True, tools='box_select,reset', tooltips=None):
     '''
     ARGS:
         source :  ColumnDataSource object
@@ -49,20 +49,19 @@ def plot_fibers(source, name, cam=None, width=250, height=270, zmin=None,
     #- TODO: add customizable clipping (percentiles, zmins, zmaxs)
     
     #- adjusts for outliers on the full scale
-    pmin, pmax = np.percentile(full_metric, (2.5, 97.5))
-    full_metric = np.clip(full_metric, pmin, pmax)
+    pmin, pmax = np.percentile(full_metric, (0, 95))
+    #full_metric = np.clip(full_metric, pmin, pmax)
 
     #- Generate colors for both plots
     palette = np.array(bp.RdYlBu[11])
-    mapper = linear_cmap(name, palette, low=min(full_metric), high=max(full_metric),
-                         nan_color='gray')
-    palette = mapper['transform'].palette
+    mapper = linear_cmap(name, palette, low=pmin, high=pmax, nan_color='gray')
     
     #- Focal plane colored scatter plot
     fig = bk.figure(width=width, height=height, title=title, tools=tools, 
                     x_range=plate_x_range, y_range=plate_y_range)
 
     #- Filter data to just this camera
+    #- TODO: DOES THIS WORK WITHOUT A CAM ARGUMENT PASSED IN?
     booleans_metric = np.char.upper(np.array(source.data['CAM']).astype(str)) == cam.upper()
     view_metric = CDSView(source=source, filters=[BooleanFilter(booleans_metric)])
         #- TODO: switch to group filter
@@ -78,19 +77,6 @@ def plot_fibers(source, name, cam=None, width=250, height=270, zmin=None,
     booleans_empty = [fiber in ii for fiber in range(len(source.data))]
     view_empty = CDSView(source=source, filters=[BooleanFilter(booleans_empty)])    
     fig.scatter('X', 'Y', source=source, view=view_empty, fill_color='#DDDDDD', radius=2)
-
-    #- Histogram of values
-    metric = full_metric[booleans_metric]
-    
-    if any(booleans_metric):
-        if percentile:
-            pmin, pmax = np.percentile(metric, percentile)
-            metric = np.clip(metric, pmin, pmax)
-        if zmin or zmax:
-            metric = np.clip(metric, zmin, zmax)
-    
-    hfig = plot_histogram(metric, palette=palette, title=name, width=width,
-                          x_range=hist_x_range, num_bins=50)
 
     
     #- Aesthetics: outline the focal plates by camera color, label cameras,
@@ -118,14 +104,28 @@ def plot_fibers(source, name, cam=None, width=250, height=270, zmin=None,
     fig.yaxis.major_label_text_font_size = '0pt'
     
     if colorbar:
-        fig.plot_width = fig.plot_width + 30
+        fig.plot_width = fig.plot_width + 60
         color_bar = ColorBar(color_mapper=mapper['transform'], label_standoff=8, border_line_color=None,
                 location=(0,0), ticker=BasicTicker(), width=10, 
                 formatter=NumeralTickFormatter(format='0.0a'))
         fig.add_layout(color_bar, 'right')
 
     
+    if not plot_hist:
+        return fig, None
+    
+    #- Histogram of values
+    metric = full_metric[booleans_metric]
+    
+    if any(booleans_metric):
+        if percentile:
+            pmin, pmax = np.percentile(metric, percentile)
+            metric = np.clip(metric, pmin, pmax)
+        if zmin or zmax:
+            metric = np.clip(metric, zmin, zmax)
+    
+    hfig = plot_histogram(metric, title=name, width=width, x_range=hist_x_range, num_bins=50)
+    
     
     return fig, hfig
-
 

--- a/py/qqa/plots/fiber.py
+++ b/py/qqa/plots/fiber.py
@@ -19,7 +19,7 @@ from ..plots.core import get_colors, plot_histogram
 
 def plot_fibers(source, name, cam=None, width=250, height=270, zmin=None, 
                 zmax=None, percentile=None, title=None, x_range=None,
-                tools='pan,box_select,reset', tooltips=None):
+                tools='box_select,reset', tooltips=None):
     '''TODO: document
     ARGS:
         source :  ColumnDataSource object

--- a/py/qqa/plots/fiber.py
+++ b/py/qqa/plots/fiber.py
@@ -19,7 +19,7 @@ from ..plots.core import get_colors, plot_histogram
 
 def plot_fibers(source, name, cam=None, width=250, height=270, zmin=None, 
                 zmax=None, percentile=None, title=None, x_range=None,
-                tools=None, tooltips=None):
+                tools='pan,box_select,reset', tooltips=None):
     '''TODO: document
     ARGS:
         source :  ColumnDataSource object

--- a/py/qqa/plots/fiber.py
+++ b/py/qqa/plots/fiber.py
@@ -21,8 +21,7 @@ from bokeh.models import ColorBar, BasicTicker, NumeralTickFormatter
 from ..plots.core import get_colors, plot_histogram
 
 
-
-def plot_fibers(source, name, cam=None, width=250, height=270, zmin=None, 
+def plot_fibers(source, name, cam=None, width=250, height=270, zmin=None,
                 zmax=None, percentile=None, title=None, hist_x_range=None,
                 plate_x_range=None, plate_y_range=None, colorbar=False,
                 plot_hist=True, tools='box_select,reset', tooltips=None):
@@ -47,7 +46,7 @@ def plot_fibers(source, name, cam=None, width=250, height=270, zmin=None,
     '''
     full_metric = np.array(source.data.get(name), copy=True)
     #- TODO: add customizable clipping (percentiles, zmins, zmaxs)
-    
+
     #- adjusts for outliers on the full scale
     pmin, pmax = np.percentile(full_metric, (0, 95))
     #full_metric = np.clip(full_metric, pmin, pmax)
@@ -55,9 +54,9 @@ def plot_fibers(source, name, cam=None, width=250, height=270, zmin=None,
     #- Generate colors for both plots
     palette = np.array(bp.RdYlBu[11])
     mapper = linear_cmap(name, palette, low=pmin, high=pmax, nan_color='gray')
-    
+
     #- Focal plane colored scatter plot
-    fig = bk.figure(width=width, height=height, title=title, tools=tools, 
+    fig = bk.figure(width=width, height=height, title=title, tools=tools,
                     x_range=plate_x_range, y_range=plate_y_range)
 
     #- Filter data to just this camera
@@ -65,20 +64,20 @@ def plot_fibers(source, name, cam=None, width=250, height=270, zmin=None,
     booleans_metric = np.char.upper(np.array(source.data['CAM']).astype(str)) == cam.upper()
     view_metric = CDSView(source=source, filters=[BooleanFilter(booleans_metric)])
         #- TODO: switch to group filter
-    
+
     #- Plot only the fibers which measured the metric
-    s = fig.scatter('X', 'Y', source=source, view=view_metric, color=mapper, 
+    s = fig.scatter('X', 'Y', source=source, view=view_metric, color=mapper,
                     radius=5, alpha=0.7)#, hover_color='firebrick')
 
-    
+
     #- Plot the rest of the fibers
     fibers_measured = source.data['FIBER'][booleans_metric]
     ii = ~np.in1d(source.data['FIBER'], fibers_measured)
     booleans_empty = [fiber in ii for fiber in range(len(source.data))]
-    view_empty = CDSView(source=source, filters=[BooleanFilter(booleans_empty)])    
+    view_empty = CDSView(source=source, filters=[BooleanFilter(booleans_empty)])
     fig.scatter('X', 'Y', source=source, view=view_empty, fill_color='#DDDDDD', radius=2)
 
-    
+
     #- Aesthetics: outline the focal plates by camera color, label cameras,
     #- style visual attributes of the figure
     camcolors = dict(B='steelblue', R='firebrick', Z='gray')
@@ -102,30 +101,29 @@ def plot_fibers(source, name, cam=None, width=250, height=270, zmin=None,
     fig.yaxis.axis_line_color = None
     fig.xaxis.major_label_text_font_size = '0pt'
     fig.yaxis.major_label_text_font_size = '0pt'
-    
+
     if colorbar:
         fig.plot_width = fig.plot_width + 60
         color_bar = ColorBar(color_mapper=mapper['transform'], label_standoff=8, border_line_color=None,
-                location=(0,0), ticker=BasicTicker(), width=10, 
+                location=(0,0), ticker=BasicTicker(), width=10,
                 formatter=NumeralTickFormatter(format='0.0a'))
         fig.add_layout(color_bar, 'right')
 
-    
+
     if not plot_hist:
         return fig, None
-    
+
     #- Histogram of values
     metric = full_metric[booleans_metric]
-    
+
     if any(booleans_metric):
         if percentile:
             pmin, pmax = np.percentile(metric, percentile)
             metric = np.clip(metric, pmin, pmax)
         if zmin or zmax:
             metric = np.clip(metric, zmin, zmax)
-    
-    hfig = plot_histogram(metric, title=name, width=width, x_range=hist_x_range, num_bins=50)
-    
-    
-    return fig, hfig
 
+    hfig = plot_histogram(metric, title=name, width=width, x_range=hist_x_range, num_bins=50)
+
+    return fig, hfig
+    

--- a/py/qqa/plots/fiber.py
+++ b/py/qqa/plots/fiber.py
@@ -48,10 +48,10 @@ def plot_fibers(source, name, cam=None, width=250, height=270, zmin=None,
     
     #- Plot only the fibers which measured the metric
     s = fig.scatter('X', 'Y', source=source, view=view_metric, color=name+'_color', 
-                    radius=5, alpha=0.7, hover_color='firebrick')
-    #- Add hover tool
-    hover = HoverTool(renderers = [s], tooltips=tooltips)
-    fig.add_tools(hover)
+                    radius=5, alpha=0.7)#, hover_color='firebrick')
+    # #- Add hover tool
+    # hover = HoverTool(renderers = [s], tooltips=tooltips)
+    # fig.add_tools(hover)
 
     
     #- Plot the rest of the fibers
@@ -72,8 +72,6 @@ def plot_fibers(source, name, cam=None, width=250, height=270, zmin=None,
         color = camcolors[cam.upper()]
         fig.ellipse(x=[0,], y=[0,], width=830, height=830, fill_color=None,
                     line_color=color, line_alpha=0.5, line_width=2)
-
-    if cam:
         fig.text([-350,], [350,], [cam.upper(),],
             text_color=camcolors[cam.upper()],
             text_align='center', text_baseline='middle')
@@ -89,6 +87,7 @@ def plot_fibers(source, name, cam=None, width=250, height=270, zmin=None,
     fig.yaxis.axis_line_color = None
     fig.xaxis.major_label_text_font_size = '0pt'
     fig.yaxis.major_label_text_font_size = '0pt'
+
 
     #- Histogram of values
     if any(booleans_metric):

--- a/py/qqa/webpages/camfiber.py
+++ b/py/qqa/webpages/camfiber.py
@@ -48,13 +48,12 @@ def write_camfiber_html(outfile, data, header):
               'Median Calibration S/N'}
     TITLESPERCAM = {'B':TITLES}
     TOOLS = 'box_select,reset'
-    
+
+
     #- Gets a shared ColumnDataSource of DATA
     cds = create_cds(data, ATTRIBUTES)
 
-    # TOOLTIPS = [('FIBER', "@FIBER")]
-    # TOOLTIPS.extend([(col, "@"+col) for col in ATTRIBUTES if col in list(cds.data.keys())])
-    
+
     #- Gets the html components for each camfib plot in ATTRIBUTES
     for attr in ATTRIBUTES:
         plot_per_camfiber(cds, attr, CAMERAS, html_components, percentiles=PERCENTILES,
@@ -73,6 +72,10 @@ def write_camfiber_html(outfile, data, header):
 def create_cds(data, attributes):
     '''
     Creates a ColumnDataSource object from DATA
+    Args:
+        data : a fits file of camfib data collected
+        attributes : a list of metrics
+
     Returns a bokeh ColumnDataSource object
     '''
     #- Get the positions of the fibers on the focal plane
@@ -82,7 +85,7 @@ def create_cds(data, attributes):
     #- bytes vs. str
     data = Table(data)
     data['CAM'] = data['CAM'].astype(str)
-
+    
     #- Join the metrics data with the corresponding fibers
     #- TODO: use input fibermap instead
     if len(data) > 0:
@@ -94,7 +97,6 @@ def create_cds(data, attributes):
             data_dict[colname] = data[colname].astype(np.float32)
         else:
             data_dict[colname] = data[colname]
-    
     cds = ColumnDataSource(data=data_dict)
     
     return cds

--- a/py/qqa/webpages/camfiber.py
+++ b/py/qqa/webpages/camfiber.py
@@ -47,7 +47,7 @@ def write_camfiber_html(outfile, data, header):
               'MEDIAN_CALIB_FLUX':'Median Calibration Flux', 'MEDIAN_CALIB_SNR':
               'Median Calibration S/N'}
     TITLESPERCAM = {'B':TITLES}
-    TOOLS = ['box_select', 'reset']
+    TOOLS = 'box_select,reset'
     
     #- Gets a shared ColumnDataSource of DATA
     cds = create_cds(data, ATTRIBUTES)

--- a/py/qqa/webpages/camfiber.py
+++ b/py/qqa/webpages/camfiber.py
@@ -81,15 +81,17 @@ def create_cds(data, attributes):
     #- Get the positions of the fibers on the focal plane
     fiberpos = Table(desimodel.io.load_fiberpos())
     fiberpos.remove_column('SPECTRO')
-
-    #- bytes vs. str
-    data = Table(data)
-    data['CAM'] = data['CAM'].astype(str)
     
     #- Join the metrics data with the corresponding fibers
     #- TODO: use input fibermap instead
+    data = Table(data)
     if len(data) > 0:
         data = join(data, fiberpos, keys='FIBER')
+        
+        #- bytes vs. strings
+        for colname in data.colnames:
+            if data[colname].dtype.kind == 'S':
+                data[colname] = data[colname].astype(str)
 
     data_dict = dict({})
     for colname in data.dtype.names:

--- a/py/qqa/webpages/camfiber.py
+++ b/py/qqa/webpages/camfiber.py
@@ -1,17 +1,18 @@
 import numpy as np
-
 import jinja2
-
 import bokeh
-import bokeh.plotting as bk
+import desimodel.io
+
 from bokeh.embed import components
 from bokeh.layouts import layout
 
-from ..plots.fiber import plot_fibers
-from ..plots.camfiber import plot_per_camfiber
-import desimodel.io
+import bokeh.plotting as bk
 from bokeh.models import ColumnDataSource
 from astropy.table import Table, join
+
+from ..plots.fiber import plot_fibers
+from ..plots.camfiber import plot_per_camfiber
+
 
 def write_camfiber_html(outfile, data, header):
     '''TODO: document'''
@@ -54,7 +55,6 @@ def write_camfiber_html(outfile, data, header):
     #- Gets a shared ColumnDataSource of DATA
     cds = create_cds(data, ATTRIBUTES)
 
-
     #- Gets the gridplots for each metric in ATTRIBUTES
     gridlist = []
     for attr in ATTRIBUTES:
@@ -68,6 +68,7 @@ def write_camfiber_html(outfile, data, header):
     #- Gets the html components of the camfiber plots
     script, div = components(camfiber_layout)
     html_components['METRIC_PLOTS'] = dict(script=script, div=div)
+
     #- Combine template + components -> HTML
     html = template.render(**html_components)
 

--- a/py/qqa/webpages/camfiber.py
+++ b/py/qqa/webpages/camfiber.py
@@ -50,7 +50,7 @@ def write_camfiber_html(outfile, data, header):
     TOOLS = ['box_select', 'reset']
     
     #- Gets a shared ColumnDataSource of DATA
-    cds = create_cds(dat, ATTRIBUTES)
+    cds = create_cds(data, ATTRIBUTES)
 
     # TOOLTIPS = [('FIBER', "@FIBER")]
     # TOOLTIPS.extend([(col, "@"+col) for col in ATTRIBUTES if col in list(cds.data.keys())])

--- a/py/qqa/webpages/camfiber.py
+++ b/py/qqa/webpages/camfiber.py
@@ -8,10 +8,13 @@ from bokeh.embed import components
 
 from ..plots.fiber import plot_fibers
 from ..plots.camfiber import plot_per_camfiber
+import desimodel.io
+from bokeh.models import ColumnDataSource
+from astropy.table import Table, join
 
 def write_camfiber_html(outfile, data, header):
     '''TODO: document'''
-    
+
     night = header['NIGHT']
     expid = header['EXPID']
     flavor = header['FLAVOR'].rstrip()
@@ -32,31 +35,62 @@ def write_camfiber_html(outfile, data, header):
         flavor=flavor, program=program, qatype = 'camfiber',
     )
 
-    #- TODO: refactor these to reduce replicated code, while still supporting
-    #- customizations like percentile vs. zmin/zmax
+    #- List of attributes to plot per camfiber with default arguments
+    ATTRIBUTES = ['INTEG_RAW_FLUX', 'MEDIAN_RAW_FLUX', 'MEDIAN_RAW_SNR', 'INTEG_CALIB_FLUX',
+                 'MEDIAN_CALIB_FLUX', 'MEDIAN_CALIB_SNR']
 
     #- Default cameras and percentile ranges for camfiber plots
     CAMERAS = ['B', 'R', 'Z']
     PERCENTILES = {'B':(0, 95), 'R':(0, 95), 'Z':(0, 98)}
-    #- List of attributes to plot per camfiber with default arguments
-    ATTRIBUTES = ['INTEG_RAW_FLUX', 'MEDIAN_RAW_FLUX', 'MEDIAN_RAW_SNR', 'INTEG_CALIB_FLUX',
-                 'MEDIAN_CALIB_FLUX', 'MEDIAN_CALIB_SNR']
-    TITLES = {'INTEG_RAW_FLUX':'Integrated Raw Counts', 'MEDIAN_RAW_FLUX':'Median Raw Counts', 
+    TITLES = {'INTEG_RAW_FLUX':'Integrated Raw Counts', 'MEDIAN_RAW_FLUX':'Median Raw Counts',
               'MEDIAN_RAW_SNR':'Median S/N', 'INTEG_CALIB_FLUX':'Integrated Calibration Flux',
               'MEDIAN_CALIB_FLUX':'Median Calibration Flux', 'MEDIAN_CALIB_SNR':
               'Median Calibration S/N'}
     TITLESPERCAM = {'B':TITLES}
+    TOOLS = ['box_select', 'reset']
     
+    #- Gets a shared ColumnDataSource of DATA
+    cds = create_cds(data)
+
+    TOOLTIPS = [('FIBER', "@FIBER")]
+    TOOLTIPS.extend([(col, "@"+col) for col in ATTRIBUTES if col in list(cds.data.keys())])
+    
+    #- Gets the html components for each camfib plot in ATTRIBUTES
     for attr in ATTRIBUTES:
-        plot_per_camfiber(data, attr, CAMERAS, html_components, percentiles=PERCENTILES, 
-            titles=TITLESPERCAM)
-            
+        plot_per_camfiber(cds, attr, CAMERAS, html_components, percentiles=PERCENTILES,
+            titles=TITLESPERCAM, tools=TOOLS, tooltips=TOOLTIPS)
+
     #- Combine template + components -> HTML
     html = template.render(**html_components)
-    
+
     #- Write HTML text to the output file
     with open(outfile, 'w') as fx:
         fx.write(html)
 
     return html_components
+
+
+def create_cds(data):
+    '''
+    Creates a ColumnDataSource object from DATA
+    Returns a bokeh ColumnDataSource object
+    '''
+    #- Get the positions of the fibers on the focal plane
+    fiberpos = Table(desimodel.io.load_fiberpos())
+    fiberpos.remove_column('SPECTRO')
+
+    #- bytes vs. str
+    data = Table(data)
+    data['CAM'] = data['CAM'].astype(str)
+
+    #- Join the metrics data with the corresponding fibers
+    #- TODO: use input fibermap instead
+    if len(data) > 0:
+        data = join(data, fiberpos, keys='FIBER')
+
+    data_dict = dict({})
+    for colname in data.dtype.names:
+        data_dict[colname] = data[colname]
+    cds = ColumnDataSource(data=data_dict)
     
+    return cds

--- a/py/qqa/webpages/camfiber.py
+++ b/py/qqa/webpages/camfiber.py
@@ -57,7 +57,7 @@ def write_camfiber_html(outfile, data, header):
     #- Gets the html components for each camfib plot in ATTRIBUTES
     for attr in ATTRIBUTES:
         plot_per_camfiber(cds, attr, CAMERAS, html_components, percentiles=PERCENTILES,
-            titles=TITLESPERCAM)
+            titles=TITLESPERCAM, tools=TOOLS)
 
     #- Combine template + components -> HTML
     html = template.render(**html_components)

--- a/py/qqa/webpages/camfiber.py
+++ b/py/qqa/webpages/camfiber.py
@@ -50,7 +50,7 @@ def write_camfiber_html(outfile, data, header):
     TOOLS = ['box_select', 'reset']
     
     #- Gets a shared ColumnDataSource of DATA
-    cds = create_cds(data)
+    cds = create_cds(dat, ATTRIBUTES)
 
     # TOOLTIPS = [('FIBER', "@FIBER")]
     # TOOLTIPS.extend([(col, "@"+col) for col in ATTRIBUTES if col in list(cds.data.keys())])
@@ -70,7 +70,7 @@ def write_camfiber_html(outfile, data, header):
     return html_components
 
 
-def create_cds(data):
+def create_cds(data, attributes):
     '''
     Creates a ColumnDataSource object from DATA
     Returns a bokeh ColumnDataSource object
@@ -90,7 +90,11 @@ def create_cds(data):
 
     data_dict = dict({})
     for colname in data.dtype.names:
-        data_dict[colname] = data[colname]
+        if colname in attributes:
+            data_dict[colname] = data[colname].astype(np.float32)
+        else:
+            data_dict[colname] = data[colname]
+    
     cds = ColumnDataSource(data=data_dict)
     
     return cds

--- a/py/qqa/webpages/templates/camfiber.html
+++ b/py/qqa/webpages/templates/camfiber.html
@@ -7,40 +7,11 @@
  -->
 {# Each plot is wrapped in if/endif for robustness against missing plots #}
 
-{% if INTEG_RAW_FLUX %}
+{% if METRIC_PLOTS %}
     <div>
-        {{ INTEG_RAW_FLUX.script }} {{ INTEG_RAW_FLUX.div }}
+        {{ METRIC_PLOTS.script }} {{ METRIC_PLOTS.div }}
     </div>
 {% endif %}
 
-{% if MEDIAN_RAW_FLUX %}
-    <div>
-        {{ MEDIAN_RAW_FLUX.script }} {{ MEDIAN_RAW_FLUX.div }}
-    </div>
-{% endif %}
-
-{% if MEDIAN_RAW_SNR %}
-    <div>
-        {{ MEDIAN_RAW_SNR.script }} {{ MEDIAN_RAW_SNR.div }}
-    </div>
-{% endif %}
-
-{% if INTEG_CALIB_FLUX %}
-    <div>
-        {{ INTEG_CALIB_FLUX.script }} {{ INTEG_CALIB_FLUX.div }}
-    </div>
-{% endif %}
-
-{% if MEDIAN_CALIB_FLUX %}
-    <div>
-        {{ MEDIAN_CALIB_FLUX.script }} {{ MEDIAN_CALIB_FLUX.div }}
-    </div>
-{% endif %}
-
-{% if MEDIAN_CALIB_SNR %}
-    <div>
-        {{ MEDIAN_CALIB_SNR.script }} {{ MEDIAN_CALIB_SNR.div }}
-    </div>
-{% endif %}
 
 {% endblock %}


### PR DESCRIPTION
Transforms camfiber data into a column data source
- All functions which take in data for plotting are modified to support this
- Moves get_colors and plot_histogram into the plots/core.py for common usage
- Currently, the biggest change is that the hues for a particular metric are generated before plotting, so it does not support camera-specific clipping (via percentiles and hardcoded min and max cutoffs)
- This is because plotting with a CDS requires all bokeh.plotting function inputs to be generated from the CDS, so the colors had to be added as columns to the CDS
- Still working on a way to customize this
The histogram ranges across a particular attribute are common to all cameras, but the coloring and axis labels/ticks/scale need more work, for a different PR

The goal was to compress the generated camfib html files
- Will also consider changing the data to single precision floating point #s before merging
Another reason was to support linked features (selection, hover) but this will also go in a different PR
