### PR TITLE
added spectra plots to flask app

### DIFF
--- a/bin/qqa_web_app.py
+++ b/bin/qqa_web_app.py
@@ -94,15 +94,23 @@ def test_timeseries(start_date, end_date, hdu, attribute):
 @app.route('/<int:night>/<string:expid>/spectra/')
 def redirect_to_spectrograph_stectra(night, expid):
     print('redirecting to spectrograph stectra')
-    return redirect('{}/{}/spectra/spectrograph'.format(night, expid), code=302)
+    return redirect('{}/{}/spectra/spectrograph/2x/'.format(night, expid), code=302)
 
-@app.route('/<int:night>/<int:expid>/spectra/<string:view>/', defaults={'select_string': None})
-@app.route('/<int:night>/<int:expid>/spectra/<string:view>/<string:select_string>')
-def getspectra(night, expid, view, select_string):
+@app.route('/<int:night>/<int:expid>/spectra/input/', defaults={'select_string': None, 'downsample': None})
+@app.route('/<int:night>/<int:expid>/spectra/input/<string:select_string>/<string:downsample>/')
+def getspectrainput(night, expid, select_string, downsample):
     global data
     data = os.path.abspath(data)
     from qqa.webpages import spectra
-    return spectra.get_spectra_html(os.path.join(data, str(night)), expid, view, select_string)
+    return spectra.get_spectra_html(os.path.join(data, str(night)), expid, "input", downsample, select_string)
+
+@app.route('/<int:night>/<int:expid>/spectra/<string:view>/', defaults={'downsample': None})
+@app.route('/<int:night>/<int:expid>/spectra/<string:view>/<string:downsample>/')
+def getspectra(night, expid, view, downsample):
+    global data
+    data = os.path.abspath(data)
+    from qqa.webpages import spectra
+    return spectra.get_spectra_html(os.path.join(data, str(night)), expid, view, downsample)
 
 @app.route('/<path:filepath>')
 def getfile(filepath):

--- a/bin/qqa_web_app.py
+++ b/bin/qqa_web_app.py
@@ -91,6 +91,19 @@ def test_timeseries(start_date, end_date, hdu, attribute):
 
     return template.render(html_components)
 
+@app.route('/<int:night>/<string:expid>/spectra/')
+def redirect_to_spectrograph_stectra(night, expid):
+    print('redirecting to spectrograph stectra')
+    return redirect('{}/{}/spectra/spectrograph'.format(night, expid), code=302)
+
+@app.route('/<int:night>/<int:expid>/spectra/<string:view>/', defaults={'select_string': None})
+@app.route('/<int:night>/<int:expid>/spectra/<string:view>/<string:select_string>')
+def getspectra(night, expid, view, select_string):
+    global data
+    data = os.path.abspath(data)
+    from qqa.webpages import spectra
+    return spectra.get_spectra_html(os.path.join(data, str(night)), expid, view, select_string)
+
 @app.route('/<path:filepath>')
 def getfile(filepath):
     global stat

--- a/py/qqa/plots/spectra.py
+++ b/py/qqa/plots/spectra.py
@@ -1,0 +1,287 @@
+from astropy.io import fits
+import bokeh.plotting as bk
+from bokeh.layouts import gridplot
+from bokeh.models import ColumnDataSource, Range1d, Title, HoverTool
+import numpy as np
+import random, os, sys, re
+
+def plot_spectra_spectro(data, expid_num, num_fibs=3, height=250, width=320):
+    p1 = []
+    p2 = []
+    first = None
+    expid = str(expid_num).zfill(8)
+    for spectro in range(0, 10, 1):
+        colors = {}
+        fib = []
+        try:
+            fib += [list(fits.getdata(os.path.join(data, expid, 'qframe-r{}-{}.fits'.format(spectro, expid)), 5)["FIBER"])]
+            colors["R"] = "red"
+        except:
+            print("could not find {}".format(os.path.join(data, expid, 'qframe-r{}-{}.fits'.format(spectro, expid))), file=sys.stderr)
+        try:
+            fib += [list(fits.getdata(os.path.join(data, expid, 'qframe-b{}-{}.fits'.format(spectro, expid)), 5)["FIBER"])]
+            colors["B"] = "blue"
+        except:
+            print("could not find {}".format(os.path.join(data, expid, 'qframe-b{}-{}.fits'.format(spectro, expid))), file=sys.stderr)
+        try:
+            fib += [list(fits.getdata(os.path.join(data, expid, 'qframe-z{}-{}.fits'.format(spectro, expid)), 5)["FIBER"])]
+            colors["Z"] = "green"
+        except:
+            print("could not find {}".format(os.path.join(data, expid, 'qframe-b{}-{}.fits'.format(spectro, expid))), file=sys.stderr)
+
+        common = []
+        for fiber in fib:
+            if common == []:
+                common = fiber
+            else:
+                common = list(set(common).intersection(fiber))
+        if len(common) > num_fibs:
+            common = random.sample(common, k=num_fibs)
+        if len(fib) > 0:
+            indexes = [fib[0].index(i) for i in common]
+        else:
+            indexes = []
+        fig=bk.figure(plot_height = height, plot_width = width+50)
+        fig.add_layout(Title(text= "Fibers: {}".format(common), text_font_style="italic"), 'above')
+        fig.add_layout(Title(text="Spectro: {}".format(spectro), text_font_size="16pt"), 'above')
+        tooltips = tooltips=[
+            ("Fiber", "@fiber"),
+            ("Cam", "@cam"),
+            ("Wavelength", "@wave"),
+            ("Flux", "@flux")
+        ]
+
+        hover = HoverTool(
+            tooltips=tooltips
+        )
+
+        fig.add_tools(hover)
+        if spectro not in [0, 5]:
+            fig.yaxis.visible = False
+            fig.plot_width = width
+
+        flux_total = []
+        for cam in colors:
+            wavelength = fits.getdata(os.path.join(data, expid, 'qframe-{}{}-{}.fits'.format(cam.lower(), spectro, expid)), "WAVELENGTH")
+            flux = fits.getdata(os.path.join(data, expid, 'qframe-{}{}-{}.fits'.format(cam.lower(), spectro, expid)), "FLUX")
+            if first is None:
+                flux_total += [val for sublist in flux for val in sublist]
+            for i in indexes:
+                length = len(wavelength[i])
+                source = ColumnDataSource(data=dict(
+                            fiber = [fib[0][i]]*length,
+                            cam = [cam]*length,
+                            wave = wavelength[i],
+                            flux = flux[i]
+                        ))
+                fig.line("wave", "flux", source=source, alpha=0.5, color=colors[cam])
+
+        if first is None:
+            if len(colors) == 3:
+                upper = int(np.percentile(flux_total, 99.99))
+                fig.y_range = Range1d(int(-0.02*upper), upper)
+                first = fig
+
+        if (spectro<5):
+            p1 += [fig]
+        else:
+            p2 += [fig]
+
+    for fig in p1:
+        fig.x_range=first.x_range
+        fig.y_range=first.y_range
+
+    for fig in p2:
+        fig.x_range=first.x_range
+        fig.y_range=first.y_range
+
+    grid = gridplot([p1, p2], sizing_mode="fixed")
+    return grid
+
+def plot_spectra_objtype(data, expid_num, num_fibs=5, height=500, width=1000):
+    colors = {"R":"red", "B":"blue", "Z":"green"}
+    expid = str(expid_num).zfill(8)
+
+    onlyfiles = [f for f in os.listdir(os.path.join(data, expid)) if os.path.isfile(os.path.join(data, expid, f))]
+    qframes = [i for i in onlyfiles if re.match(r'qframe.*', i)]
+    spectr = [int(i.split("-")[1][1]) for i in qframes]
+    spectros = random.choices(list(set(spectr)), k=num_fibs)
+
+    gridlist = []
+    unique_objs = list(set(fits.getdata(os.path.join(data, expid, qframes[0]), 5)["OBJTYPE"]))
+    unique_objs.sort()
+    for obj in unique_objs:
+        fig=bk.figure(plot_height = height, plot_width = width)
+        com = []
+        first = True
+        for spectro in spectros:
+            r_fib = fits.getdata(os.path.join(data, expid, 'qframe-r{}-{}.fits'.format(spectro, expid)), 5)
+            bool_array = r_fib["OBJTYPE"] == obj
+            r_fib = r_fib["FIBER"]
+            r_fib = [r_fib[i] if bool_array[i] else None for i in range(len(r_fib))]
+
+            b_fib = fits.getdata(os.path.join(data, expid, 'qframe-b{}-{}.fits'.format(spectro, expid)), 5)
+            b_fib = b_fib[b_fib["OBJTYPE"] == obj]["FIBER"]
+
+            z_fib = fits.getdata(os.path.join(data, expid, 'qframe-z{}-{}.fits'.format(spectro, expid)), 5)
+            z_fib = z_fib[z_fib["OBJTYPE"] == obj]["FIBER"]
+
+            common = list(set(r_fib).intersection(b_fib).intersection(z_fib))
+            if len(common) > 1:
+                common = random.sample(common, k=1)
+            com += common
+            indexes = [r_fib.index(i) for i in common]
+            if first:
+                flux_total = []
+            for cam in colors:
+                if indexes == []:
+                    continue
+                wavelength = fits.getdata(os.path.join(data, expid, 'qframe-{}{}-{}.fits'.format(cam.lower(), spectro, expid)), "WAVELENGTH")
+                flux = fits.getdata(os.path.join(data, expid, 'qframe-{}{}-{}.fits'.format(cam.lower(), spectro, expid)), "FLUX")
+                if first:
+                    flux_total += [val for sublist in flux for val in sublist]
+                for i in indexes:
+                    length = len(wavelength[i])
+                    source = ColumnDataSource(data=dict(
+                                fiber = [r_fib[i]]*length,
+                                cam = [cam]*length,
+                                wave = wavelength[i],
+                                flux = flux[i]
+                            ))
+                    fig.line("wave", "flux", source=source, alpha=0.5, color=colors[cam])
+            first = False
+
+        #grid = gridplot(p1, p2)
+        fig.add_layout(Title(text= "Fibers: {}".format(com), text_font_style="italic"), 'above')
+        fig.add_layout(Title(text= "OBJTYPE: {}".format(obj), text_font_size="16pt"), 'above')
+
+        tooltips = tooltips=[
+            ("Fiber", "@fiber"),
+            ("Cam", "@cam"),
+            ("Wavelength", "@wave"),
+            ("Flux", "@flux")
+        ]
+
+        hover = HoverTool(
+            tooltips=tooltips
+        )
+
+        fig.add_tools(hover)
+
+        upper = int(np.percentile(flux_total, 99.99))
+        fig.y_range = Range1d(int(-0.02*upper), upper)
+        gridlist += [[fig]]
+    return gridplot(gridlist, sizing_mode="fixed")
+
+def lister(string):
+    try:
+        str_spl = string.split(',')
+        result = []
+        for sub in str_spl:
+            if '-' in sub:
+                between = sub.split('-')
+                if len(between) != 2:
+                    return None
+                lower = int(between[0])
+                upper = int(between[1])+1
+                result += range(lower, upper, 1)
+            else:
+                result += [int(sub)]
+        return result
+    except:
+        return None
+
+def grouper(lst):
+    result = {}
+    for i in range(500, 5001, 500):
+        sub = [j for j in lst if j < i]
+        if len(sub) > 0:
+            result[int(i/500)-1] = sub
+        lst = [j for j in lst if j >= i]
+    return result
+
+def plot_spectra_input(data, expid_num, select_string, height=500, width=1000):
+    fibers = lister(select_string)
+    if fibers is None:
+        return None
+
+    result_able = []
+    result_not = [fiber for fiber in fibers if fiber >=5000]
+    flux_total = []
+
+    expid = str(expid_num).zfill(8)
+    colors = {"R":"red", "B":"blue", "Z":"green"}
+
+    group = grouper(fibers)
+
+    fig=bk.figure(plot_height = height, plot_width = width)
+
+    for spectro in group:
+
+        exists = os.path.isfile(os.path.join(data, expid, 'qframe-r{}-{}.fits'.format(spectro, expid))) or \
+        os.path.isfile(os.path.join(data, expid, 'qframe-b{}-{}.fits'.format(spectro, expid))) or \
+        os.path.isfile(os.path.join(data, expid, 'qframe-z{}-{}.fits'.format(spectro, expid)))
+
+        if not exists:
+            result_not += group[spectro]
+            continue
+
+        rbz_none = [False]*len(group[spectro])
+
+        for cam in colors:
+            if not os.path.isfile(os.path.join(data, expid, 'qframe-{}{}-{}.fits'.format(cam.lower(), spectro, expid))):
+                continue
+            fibs = list(fits.getdata(os.path.join(data, expid, 'qframe-{}{}-{}.fits'.format(cam.lower(), spectro, expid)), 5)["FIBER"])
+
+            fib = []
+            for f in fibs:
+                fib += [f in group[spectro]]
+
+            c_none = []
+            for f in group[spectro]:
+                c_none += [f in fibs]
+
+            rbz_none = np.any([rbz_none, c_none], axis=0)
+            indexes = np.nonzero(fib)[0]
+
+            wavelength = fits.getdata(os.path.join(data, expid, 'qframe-{}{}-{}.fits'.format(cam.lower(), spectro, expid)), "WAVELENGTH")
+            flux = fits.getdata(os.path.join(data, expid, 'qframe-{}{}-{}.fits'.format(cam.lower(), spectro, expid)), "FLUX")
+            for i in indexes:
+                length = len(wavelength[i])
+                source = ColumnDataSource(data=dict(
+                            fiber = [fibs[i]]*length,
+                            cam = [cam]*length,
+                            wave = wavelength[i],
+                            flux = flux[i]
+                        ))
+                flux_total += [val for sublist in flux for val in sublist]
+                #print(str(i), file=sys.stderr)
+                fig.line("wave", "flux", source=source, alpha=0.5, color=colors[cam])
+
+        for i in range(0, len(group[spectro]), 1):
+            if rbz_none[i]:
+                result_able += [group[spectro][i]]
+            else:
+                result_not += [group[spectro][i]]
+
+    fig.add_layout(Title(text= "Not Found: {}".format(result_not), text_font_style="italic"), 'above')
+    fig.add_layout(Title(text= "Found: {}".format(result_able), text_font_style="italic"), 'above')
+    fig.add_layout(Title(text= select_string, text_font_size="16pt"), 'above')
+
+    tooltips = tooltips=[
+        ("Fiber", "@fiber"),
+        ("Cam", "@cam"),
+        ("Wavelength", "@wave"),
+        ("Flux", "@flux")
+    ]
+
+    hover = HoverTool(
+        tooltips=tooltips
+    )
+
+    fig.add_tools(hover)
+
+    upper = int(np.percentile(flux_total, 99.99))
+    fig.y_range = Range1d(int(-0.02*upper), upper)
+
+    return fig

--- a/py/qqa/webpages/spectra.py
+++ b/py/qqa/webpages/spectra.py
@@ -1,0 +1,47 @@
+import numpy as np
+
+import jinja2
+import bokeh, sys
+from bokeh.embed import components
+
+from ..plots import spectra
+
+def get_spectra_html(data, expid, view, select_string = None):
+    '''TODO: document'''
+
+    if view not in ["spectrograph", "objtype", "input"]:
+        print("No such view " + view, file=sys.stderr)
+        return "No such view " + view
+
+    env = jinja2.Environment(
+        loader=jinja2.PackageLoader('qqa.webpages', 'templates')
+    )
+    template = env.get_template('spectra.html')
+
+    html_components = dict(
+        bokeh_version=bokeh.__version__
+    )
+
+    #- Generate the bokeh figure
+    if view == "spectrograph":
+        fig = spectra.plot_spectra_spectro(data, expid)
+    elif view == "objtype":
+        fig = spectra.plot_spectra_objtype(data, expid)
+    elif view == "input":
+        html_components["input"] = True
+        fig = None
+        if select_string != None:
+            html_components["select_str"] = select_string
+            fig = spectra.plot_spectra_input(data, expid, select_string)
+            if fig is None:
+                return "None selected"
+
+    if fig:
+        #- Convert that into the components to embed in the HTML
+        script, div = components(fig)
+        #- Save those in a dictionary to use later
+        html_components['spectra'] = dict(script=script, div=div)
+    #- Combine template + components -> HTML
+    html = template.render(**html_components)
+
+    return html

--- a/py/qqa/webpages/spectra.py
+++ b/py/qqa/webpages/spectra.py
@@ -6,7 +6,7 @@ from bokeh.embed import components
 
 from ..plots import spectra
 
-def get_spectra_html(data, expid, view, select_string = None):
+def get_spectra_html(data, expid, view, downsample_str, select_string = None):
     '''TODO: document'''
 
     if view not in ["spectrograph", "objtype", "input"]:
@@ -21,18 +21,26 @@ def get_spectra_html(data, expid, view, select_string = None):
     html_components = dict(
         bokeh_version=bokeh.__version__
     )
+    if downsample_str is None:
+        downsample = 4
+    else:
+        try:
+            downsample = int(downsample_str[0:len(downsample_str)-1])
+        except:
+            return("invalid downsample")
 
+    html_components["downsample"] = downsample
     #- Generate the bokeh figure
     if view == "spectrograph":
-        fig = spectra.plot_spectra_spectro(data, expid)
+        fig = spectra.plot_spectra_spectro(data, expid, downsample)
     elif view == "objtype":
-        fig = spectra.plot_spectra_objtype(data, expid)
+        fig = spectra.plot_spectra_objtype(data, expid, downsample)
     elif view == "input":
         html_components["input"] = True
         fig = None
         if select_string != None:
             html_components["select_str"] = select_string
-            fig = spectra.plot_spectra_input(data, expid, select_string)
+            fig = spectra.plot_spectra_input(data, expid, downsample, select_string)
             if fig is None:
                 return "None selected"
 

--- a/py/qqa/webpages/spectra.py
+++ b/py/qqa/webpages/spectra.py
@@ -24,6 +24,8 @@ def get_spectra_html(data, expid, view, downsample_str, select_string = None):
     if downsample_str is None:
         downsample = 4
     else:
+        if downsample_str[len(downsample_str)] != "x":
+            return("invalid downsample")
         try:
             downsample = int(downsample_str[0:len(downsample_str)-1])
         except:

--- a/py/qqa/webpages/spectra.py
+++ b/py/qqa/webpages/spectra.py
@@ -24,7 +24,7 @@ def get_spectra_html(data, expid, view, downsample_str, select_string = None):
     if downsample_str is None:
         downsample = 4
     else:
-        if downsample_str[len(downsample_str)] != "x":
+        if downsample_str[len(downsample_str)-1] != "x":
             return("invalid downsample")
         try:
             downsample = int(downsample_str[0:len(downsample_str)-1])
@@ -41,6 +41,7 @@ def get_spectra_html(data, expid, view, downsample_str, select_string = None):
         html_components["input"] = True
         fig = None
         if select_string != None:
+            select_string =select_string.replace(" ", "")
             html_components["select_str"] = select_string
             fig = spectra.plot_spectra_input(data, expid, downsample, select_string)
             if fig is None:

--- a/py/qqa/webpages/templates/spectra.html
+++ b/py/qqa/webpages/templates/spectra.html
@@ -3,18 +3,32 @@
 {% block body %}
 
 {# Rendering arguments: spectra(.script, .div) #}
-
+<style>
+label {
+  display: flex;
+  flex-direction: row;
+  margin-bottom: 5px;
+}
+</style>
 {% if spectra %}
     <div class=flex-item>{{ spectra.script }} {{ spectra.div }}</div>
 {% endif %}
 <br>
 {% if input %}
-<label> Select Fibers:
+<label> Fibers:
     <input type="text" id="fibs" size=40 {% if select_str %} value="{{select_str}}" {% endif %} >
 </label>
 
+<label> Downsample:
+    <input type="int" id="down" size=4 {% if downsample %} value="{{downsample}}" {% endif %} >
+</label>
+
 <button onclick='
-  var url = document.getElementById("fibs").value
+{% if select_str %}
+  var url = "../../" + document.getElementById("fibs").value + "/" + document.getElementById("down").value + "x"
+{% else %}
+  var url = document.getElementById("fibs").value + "/" + document.getElementById("down").value + "x"
+{% endif %}
   window.open(url, "_top")
 '>Generate Spectra
 </button>

--- a/py/qqa/webpages/templates/spectra.html
+++ b/py/qqa/webpages/templates/spectra.html
@@ -1,0 +1,28 @@
+{% extends "base.html" %}
+
+{% block body %}
+
+{# Rendering arguments: spectra(.script, .div) #}
+
+{% if spectra %}
+    <div class=flex-item>{{ spectra.script }} {{ spectra.div }}</div>
+{% endif %}
+<br>
+{% if input %}
+<label> Select Fibers:
+    <input type="text" id="fibs" size=40 {% if select_str %} value="{{select_str}}" {% endif %} >
+</label>
+
+<button onclick='
+  var url = document.getElementById("fibs").value
+  window.open(url, "_top")
+'>Generate Spectra
+</button>
+
+{% if not select_str %}
+<p>eg: "1, 3-5" plots fibers [1, 3, 4, 5]</p>
+{% endif %}
+
+{% endif %}
+
+{% endblock %}


### PR DESCRIPTION
Added spectra plots to flask app (addresses #36):
- Added per-spectrograph views of spectra (navigate by url/{night}/{expid}/spectra/spectrograph): 
![image](https://user-images.githubusercontent.com/35549068/59804438-2cc5dd00-92a3-11e9-90fd-3faa3157efe5.png)
  - Randomly chooses 3 fibers per spectrograph and plots its blue, red, and infrared spectras
  - All plots share pan/zoom, and support hover

- Added per-object-type views of spectra (navigate by url/{night}/{expid}/spectra/objtype):
![image](https://user-images.githubusercontent.com/35549068/59804695-f3da3800-92a3-11e9-8fc2-fb1ba2e88676.png)
  - Randomly chooses 5 fibers per objtype and plots its blue, red, and infrared spectras
  - For the read data (20190306/00001076), the objtype field is blank and is treated as 1 objtype
  - Hover tool is supported

- Added choose-specific-fibers view of spectra (navigate by url/{night}/{expid}/spectra/input):
![image](https://user-images.githubusercontent.com/35549068/59804987-d6f23480-92a4-11e9-8908-492d1a2605cf.png)
  - Plots all fibers provided by the user
  - Hover tool is supported

- I did not add the qa-header to the pages because I was not sure if we wanted to group these plots with qa plots. 
- Also, these pages are autogenerated by the flask app (on the fly, albeit a bit slow), and not generated by `qqa`. I can have the first 2 views (per-spectrograph and per-object-type) generated within `qqa`, but the input view page requires the flask app.