### PR TITLE
optionally specify host and port for webapp

### DIFF
--- a/bin/qqa_web_app.py
+++ b/bin/qqa_web_app.py
@@ -11,6 +11,8 @@ data = ""
 parser = argparse.ArgumentParser(usage = "{prog} [options]")
 parser.add_argument("-s", "--static", type=str, required=True, help="static file directory")
 parser.add_argument("-d", "--data", type=str, help="data/fits file directory")
+parser.add_argument("--host", type=str, default="localhost", help="hostname (e.g. localhost or 0.0.0.0")
+parser.add_argument("--port", type=int, default=8001, help="port number")
 args = parser.parse_args()
 
 stat = args.static
@@ -138,4 +140,4 @@ def getfile(filepath):
     return 'no data for ' + os.path.join(stat, filepath)
 
 if __name__ == "__main__":
-    app.run(debug=True)
+    app.run(debug=True, host=args.host, port=args.port)


### PR DESCRIPTION
This PR allows you to optionally specify the host and port for the qqa_web_app.py, e.g.

```
python /Users/sbailey/desi/git/qqa/bin/qqa_web_app.py -d output/ -s plots/ --host localhost --port 8123
```

The default hostname is "localhost", which is the most secure but not visible externally, so to use at KPNO to be visible from other machines within the VPN:
```
python /software/datasystems/desiconda/20180821/qqa/master/bin/qqa_web_app.py -d ... -s ... --host 0.0.0.0 --port 8001
```
