### PR TITLE
Auto-updating latest exposure summary

### DIFF
--- a/py/qqa/plots/amp.py
+++ b/py/qqa/plots/amp.py
@@ -167,9 +167,12 @@ def plot_amp_qa(data, name, title=None, qamin=None, qamax=None,
     #     qamax = np.max(data[name])
     
     labels = [(spec, amp) for spec in ['0', '1', '2', '3', '4', '5', '6', '7', '8', '9'] for amp in ['A', 'B', 'C', 'D']]
-    fig_B = plot_amp_cam_qa(data, name, 'B', labels, qamin, qamax, ymin=ymin, ymax=ymax, title=title, plot_height=plot_height+25)
-    fig_R = plot_amp_cam_qa(data, name, 'R', labels, qamin, qamax, ymin=ymin, ymax=ymax, title=title, plot_height=plot_height)
-    fig_Z = plot_amp_cam_qa(data, name, 'Z', labels, qamin, qamax, ymin=ymin, ymax=ymax, title=title, plot_height=plot_height)
+    fig_B = plot_amp_cam_qa(data, name, 'B', labels, qamin, qamax, ymin=ymin, ymax=ymax,
+        title=title, plot_height=plot_height+25, plot_width=plot_width)
+    fig_R = plot_amp_cam_qa(data, name, 'R', labels, qamin, qamax, ymin=ymin, ymax=ymax,
+        title=title, plot_height=plot_height, plot_width=plot_width)
+    fig_Z = plot_amp_cam_qa(data, name, 'Z', labels, qamin, qamax, ymin=ymin, ymax=ymax,
+        title=title, plot_height=plot_height, plot_width=plot_width)
     
     # x-axis labels for spectrograph 0-9 and amplifier A-D
     axis = bk.figure(x_range=FactorRange(*labels), toolbar_location=None, 

--- a/py/qqa/plots/amp.py
+++ b/py/qqa/plots/amp.py
@@ -5,7 +5,6 @@ import bokeh.plotting as bk
 from bokeh.models.tickers import FixedTicker
 from bokeh.models.ranges import FactorRange
 from bokeh.models import LinearColorMapper, ColorBar, ColumnDataSource, OpenURL, TapTool, Div, HoverTool, Range1d, BoxAnnotation
-import bokeh.palettes
 from bokeh.layouts import column, gridplot
 
 import json
@@ -16,12 +15,16 @@ def get_amp_colors(data, threshold):
     Input: array of amplifier metric data, upper threshold (float)
     Output: array of colors to be put into a ColumnDataSource
     '''
-    colors = []
-    for i in range(len(data)):
-        if data[i] < threshold:
-            colors.append('black')
-        if data[i] >= threshold:
-            colors.append('red')
+    if threshold is None:
+        colors = ['black',] * len(data)
+    else:
+        colors = []
+        for i in range(len(data)):
+            if data[i] < threshold:
+                colors.append('black')
+            if data[i] >= threshold:
+                colors.append('red')
+
     return colors
 
 def get_amp_size(data, threshold):
@@ -30,12 +33,16 @@ def get_amp_size(data, threshold):
     Input: array of amplifier metric data, upper threshold (float)
     Output: array of sizes for markers to be put into a ColumnDataSource
     '''
-    sizes = []
-    for i in range(len(data)):
-        if data[i] < threshold:
-            sizes.append(4)
-        if data[i] >= threshold:
-            sizes.append(6)
+    if threshold is None:
+        sizes = [4,] * len(data)
+    else:
+        sizes = []
+        for i in range(len(data)):
+            if data[i] < threshold:
+                sizes.append(4)
+            if data[i] >= threshold:
+                sizes.append(8)
+
     return sizes
 
 def isolate_spec_lines(data_locs, data):
@@ -54,9 +61,12 @@ def isolate_spec_lines(data_locs, data):
         data_groups.append(data[ids[i]:ids[i+1]])
     return spec_groups, data_groups
 
-def plot_amp_cam_qa(data, name, cam, labels, qamin, qamax, title=None, palette="YlGn9", plot_height=80, plot_width=700):
+def plot_amp_cam_qa(data, name, cam, labels, qamin, qamax,
+            ymin=None, ymax=None,
+            title=None, plot_height=80, plot_width=700):
     '''Plot a per-amp visualization of data[name]
-    qamin/qamax: min/max ranges for the color scale'''
+    qamin/qamax: min/max ranges for the color scale
+    ymin/ymax: y-axis ranges *unless* the data exceeds those ranges'''
     
     if title is None:
         title = name   
@@ -114,7 +124,18 @@ def plot_amp_cam_qa(data, name, cam, labels, qamin, qamax, title=None, palette="
                  fill_color='colors', size='sizes', source=source, name='circles')
 
     fig.yaxis.axis_label = cam
-    fig.y_range = Range1d(np.min(data_val)*0.9, np.max(data_val)*1.1)
+
+    if ymin is None:
+        ymin = np.min(data_val)*0.9
+    else:
+        ymin = min(ymin, np.min(data_val)*0.9)
+
+    if ymax is None:
+        ymax = np.max(data_val)*1.1
+    else:
+        ymax = max(ymax, np.max(data_val)*1.1)
+
+    fig.y_range = Range1d(ymin, ymax)
     fig.yaxis.minor_tick_line_color=None
     fig.ygrid.grid_line_color=None
     if cam == 'R':
@@ -126,8 +147,9 @@ def plot_amp_cam_qa(data, name, cam, labels, qamin, qamax, title=None, palette="
         fig.outline_line_color='grey'
     fig.outline_line_alpha=0.7
     
-    good_range = BoxAnnotation(bottom=qamin, top=qamax, fill_alpha=0.1, fill_color='green')
-    fig.add_layout(good_range)
+    if qamin is not None and qamax is not None:
+        good_range = BoxAnnotation(bottom=qamin, top=qamax, fill_alpha=0.1, fill_color='green')
+        fig.add_layout(good_range)
     
     taptool = fig.select(type=TapTool)
     taptool.names = ['circles']
@@ -135,20 +157,21 @@ def plot_amp_cam_qa(data, name, cam, labels, qamin, qamax, title=None, palette="
 
     return fig
 
-def plot_amp_qa(data, name, title=None, palette="YlGn9", qamin=None, qamax=None, plot_height=80, 
-                plot_width=700):
+def plot_amp_qa(data, name, title=None, qamin=None, qamax=None,
+         plot_height=80, plot_width=700,
+         ymin=None, ymax=None):
     
-    if qamin is None:
-        qamin = np.min(data[name])
-    if qamax is None:
-        qamax = np.max(data[name]) 
+    # if qamin is None:
+    #     qamin = np.min(data[name])
+    # if qamax is None:
+    #     qamax = np.max(data[name])
     
     labels = [(spec, amp) for spec in ['0', '1', '2', '3', '4', '5', '6', '7', '8', '9'] for amp in ['A', 'B', 'C', 'D']]
-    fig_B = plot_amp_cam_qa(data, name, 'B', labels, qamin, qamax, title=title, palette=palette, plot_height=plot_height+25)
-    fig_R = plot_amp_cam_qa(data, name, 'R', labels, qamin, qamax, title=title, palette=palette, plot_height=plot_height)
-    fig_Z = plot_amp_cam_qa(data, name, 'Z', labels, qamin, qamax, title=title, palette=palette, plot_height=plot_height)
+    fig_B = plot_amp_cam_qa(data, name, 'B', labels, qamin, qamax, ymin=ymin, ymax=ymax, title=title, plot_height=plot_height+25)
+    fig_R = plot_amp_cam_qa(data, name, 'R', labels, qamin, qamax, ymin=ymin, ymax=ymax, title=title, plot_height=plot_height)
+    fig_Z = plot_amp_cam_qa(data, name, 'Z', labels, qamin, qamax, ymin=ymin, ymax=ymax, title=title, plot_height=plot_height)
     
-    #x-axis
+    # x-axis labels for spectrograph 0-9 and amplifier A-D
     axis = bk.figure(x_range=FactorRange(*labels), toolbar_location=None, 
                      plot_height=50, plot_width=plot_width,
                      y_axis_location=None)         

--- a/py/qqa/plots/camfiber.py
+++ b/py/qqa/plots/camfiber.py
@@ -13,7 +13,7 @@ from ..plots.fiber import plot_fibers_focalplate, plot_fibernums
 
 def plot_camfib_focalplate(cds, attribute, cameras, percentiles={},
                       zmaxs={}, zmins={}, titles={},
-                      tools='pan,box_select,reset'):
+                      tools='pan,box_zoom,reset'):
     '''
     ARGS:
         cds : ColumnDataSource of data
@@ -85,8 +85,8 @@ def plot_camfib_focalplate(cds, attribute, cameras, percentiles={},
 
 
 
-def plot_per_fibernum(cds, attribute, cameras, titles={}, tools=None,
-        width=650, height=150):
+def plot_per_fibernum(cds, attribute, cameras, titles={},
+        tools='pan,box_zoom,reset', width=650, height=150):
     '''
     ARGS:
         cds : ColumnDataSource of data

--- a/py/qqa/plots/camfiber.py
+++ b/py/qqa/plots/camfiber.py
@@ -3,6 +3,7 @@ import jinja2
 import bokeh
 
 from astropy.table import Table
+import bokeh
 import bokeh.plotting as bk
 import bokeh.palettes as bp
 from bokeh.transform import linear_cmap
@@ -86,7 +87,8 @@ def plot_camfib_focalplate(cds, attribute, cameras, percentiles={},
 
 
 def plot_per_fibernum(cds, attribute, cameras, titles={},
-        tools='pan,box_zoom,reset', width=650, height=150):
+        tools='pan,box_zoom,reset', width=650, height=150,
+        ymin=None, ymax=None):
     '''
     ARGS:
         cds : ColumnDataSource of data
@@ -94,6 +96,7 @@ def plot_per_fibernum(cds, attribute, cameras, titles={},
         cameras : list of string representing unique camera values
         width : width of individual camera plots in pixels
         height : height of individual camera plots in pixels
+        ymin/ymax : y-axis ranges unless data exceed those ranges
 
     Options:
         titles : dictionary of titles per camera for a group of camfiber plots
@@ -122,22 +125,33 @@ def plot_per_fibernum(cds, attribute, cameras, titles={},
         min_fiber = max(0, min(list(cds.data['FIBER'])))
         max_fiber = min(5000, max(list(cds.data['FIBER'])))
         first_x_range = bokeh.models.Range1d(min_fiber-1, max_fiber+1)
-        # first_y_range = None
 
         #- shared ranges to support linked features
         if not figs_list:
             fig_x_range = first_x_range
-            # fig_y_range = first_y_range
             toolbar_location='above'
         else:
             fig_x_range = figs_list[0].x_range
-            # fig_y_range = figs_list[0].y_range
             toolbar_location=None
+
+        cam_metric = metric[cds.data.get('CAM') == c]
+        if ymin is None:
+            plotmin = np.min(cam_metric) * 0.9
+        else:
+            plotmin = min(ymin, np.min(cam_metric) * 0.9)
+
+        if ymax is None:
+            plotmax = np.max(cam_metric) * 1.1
+        else:
+            plotmax = max(ymax, np.max(cam_metric) * 1.1)
+
+        fig_y_range = bokeh.models.Range1d(plotmin, plotmax)
 
         heightpad = 25 if i==0 else 0  #- extra space for title and toolbar
         fig = plot_fibernums(cds, attribute, cam=c, title=titles.get(c, {}).get(attribute),
                              tools=tools,tooltips=tooltips, toolbar_location=toolbar_location,
-                             fig_x_range=fig_x_range, width=width, height=height+heightpad
+                             fig_x_range=fig_x_range, fig_y_range=fig_y_range,
+                             width=width, height=height+heightpad,
                             )
 
         figs_list.append(fig)

--- a/py/qqa/plots/fiber.py
+++ b/py/qqa/plots/fiber.py
@@ -148,7 +148,7 @@ def plot_fibers_focalplate(source, name, cam='',
 def plot_fibernums(source, name, cam='',
                 camcolors=dict(B='steelblue', R='firebrick', Z='green'),
                 width=650, height=150, title=None, fig_x_range=None,
-                fig_y_range=None, tools='pan,box_select,reset',
+                fig_y_range=None, tools='pan,box_zoom,reset',
                 toolbar_location=None, tooltips=None):
     '''
     ARGS:
@@ -178,7 +178,8 @@ def plot_fibernums(source, name, cam='',
 
     #- Focal plane colored scatter plot
     fig = bk.figure(width=width, height=height, title=title, tools=tools,
-                    x_range=fig_x_range, y_range=fig_y_range, toolbar_location=toolbar_location)
+                    x_range=fig_x_range, y_range=fig_y_range,
+                    toolbar_location=toolbar_location)
 
     #- Filter data to just this camera
     #- TODO: fails when CAM not in the data source provided
@@ -187,7 +188,7 @@ def plot_fibernums(source, name, cam='',
 
     #- Plot only the fibers which measured the metric
     s = fig.scatter('FIBER', name, source=source, view=view_metric,
-                    color=camcolors.get(cam.upper()), alpha=0.5)
+                    color=camcolors.get(cam.upper()), alpha=0.7)
 
     #- Add hover tool
     if not tooltips:
@@ -202,6 +203,7 @@ def plot_fibernums(source, name, cam='',
     fig.outline_line_color = None
     fig.xaxis.axis_line_color = camcolors.get(cam.upper())
     fig.yaxis.axis_line_color = camcolors.get(cam.upper())
+    fig.yaxis.formatter = NumeralTickFormatter(format='0a')
     fig.xaxis.major_label_orientation = math.pi/4
     # fig.xaxis[0].formatter = NumeralTickFormatter(format='0.0a')
 

--- a/py/qqa/plots/spectra.py
+++ b/py/qqa/plots/spectra.py
@@ -372,6 +372,10 @@ def plot_spectra_input(data, expid_num, n, select_string, height=500, width=1000
     # fig.add_layout(Title(text= "Found: {}".format(result_able), text_font_style="italic"), 'above')
     # fig.add_layout(Title(text= select_string, text_font_size="12pt"), 'above')
 
+    if len(result_able) == 0:
+        print('ERROR: Unable to find any input spectra in {} for {}'.format(
+            data, select_string))
+
     title = 'Spectra {} downsampled {}x'.format(select_string, n)
     fig.add_layout(Title(text=title), 'above')
 

--- a/py/qqa/plots/spectra.py
+++ b/py/qqa/plots/spectra.py
@@ -366,10 +366,13 @@ def plot_spectra_input(data, expid_num, n, select_string, height=500, width=1000
             else:
                 result_not += [group[spectro][i]]
 
-    fig.add_layout(Title(text= "Downsample: {}".format(n), text_font_style="italic"), 'above')
-    fig.add_layout(Title(text= "Not Found: {}".format(result_not), text_font_style="italic"), 'above')
-    fig.add_layout(Title(text= "Found: {}".format(result_able), text_font_style="italic"), 'above')
-    fig.add_layout(Title(text= select_string, text_font_size="16pt"), 'above')
+    # fig.add_layout(Title(text= "Downsample: {}".format(n), text_font_style="italic"), 'above')
+    # fig.add_layout(Title(text= "Not Found: {}".format(result_not), text_font_style="italic"), 'above')
+    # fig.add_layout(Title(text= "Found: {}".format(result_able), text_font_style="italic"), 'above')
+    # fig.add_layout(Title(text= select_string, text_font_size="12pt"), 'above')
+
+    title = 'Spectra {} downsampled {}x'.format(select_string, n)
+    fig.add_layout(Title(text=title), 'above')
 
     tooltips = tooltips=[
         ("Fiber", "@fiber"),

--- a/py/qqa/plots/spectra.py
+++ b/py/qqa/plots/spectra.py
@@ -1,7 +1,8 @@
 from astropy.io import fits
 import bokeh.plotting as bk
 from bokeh.layouts import gridplot
-from bokeh.models import ColumnDataSource, Range1d, Title, HoverTool
+from bokeh.models import ColumnDataSource, Range1d, Title, HoverTool, NumeralTickFormatter
+
 import numpy as np
 import random, os, sys, re
 
@@ -392,5 +393,6 @@ def plot_spectra_input(data, expid_num, n, select_string, height=500, width=1000
     else:
         upper = int(np.percentile(flux_total, 99.99))
     fig.y_range = Range1d(int(-0.02*upper), upper)
+    fig.yaxis.formatter = NumeralTickFormatter(format='0a')
 
     return fig

--- a/py/qqa/run.py
+++ b/py/qqa/run.py
@@ -305,7 +305,7 @@ def make_plots(infile, outdir, preprocdir=None, cameras=None):
         print('Wrote {}'.format(htmlfile))
 
     htmlfile = '{}/qa-summary-{:08d}.html'.format(outdir, expid)
-    web_summary.write_summary_html(htmlfile, qadata, plot_components)
+    web_summary.write_summary_html(htmlfile, qadata, preprocdir)
     print('Wrote {}'.format(htmlfile))
 
     #- TODO: this shouldn't go in the per-exposure directory

--- a/py/qqa/run.py
+++ b/py/qqa/run.py
@@ -310,7 +310,7 @@ def make_plots(infile, outdir, preprocdir=None, cameras=None):
 
     #- TODO: this shouldn't go in the per-exposure directory
     htmlfile = '{}/qa-lastexp.html'.format(outdir)
-    web_lastexp.write_lastexp_html(htmlfile, qadata)
+    web_lastexp.write_lastexp_html(htmlfile, qadata, preprocdir)
     print('Wrote {}'.format(htmlfile))
 
     from qqa.webpages import plotimage

--- a/py/qqa/run.py
+++ b/py/qqa/run.py
@@ -263,6 +263,7 @@ def make_plots(infile, outdir, preprocdir=None, cameras=None):
     from qqa.webpages import camfiber as web_camfiber
     from qqa.webpages import camera as web_camera
     from qqa.webpages import summary as web_summary
+    from qqa.webpages import lastexp as web_lastexp
     from . import io
 
     log = desiutil.log.get_logger()
@@ -305,6 +306,11 @@ def make_plots(infile, outdir, preprocdir=None, cameras=None):
 
     htmlfile = '{}/qa-summary-{:08d}.html'.format(outdir, expid)
     web_summary.write_summary_html(htmlfile, qadata, plot_components)
+    print('Wrote {}'.format(htmlfile))
+
+    #- TODO: this shouldn't go in the per-exposure directory
+    htmlfile = '{}/qa-lastexp.html'.format(outdir)
+    web_lastexp.write_lastexp_html(htmlfile, qadata)
     print('Wrote {}'.format(htmlfile))
 
     from qqa.webpages import plotimage

--- a/py/qqa/run.py
+++ b/py/qqa/run.py
@@ -31,7 +31,7 @@ def get_ncpu(ncpu):
 
 def find_unprocessed_expdir(datadir, outdir):
     '''
-    Returns the earliest basedir/YEARMMDD/EXPID that has not yet been processed
+    Returns the earliest outdir/YEARMMDD/EXPID that has not yet been processed
     in outdir/YEARMMDD/EXPID.
 
     Returns directory, of None if no unprocessed directories were found
@@ -242,12 +242,12 @@ def run_qa(indir, outfile=None, qalist=None):
     qarunner = QARunner(qalist)
     return qarunner.run(indir, outfile=outfile)
 
-def make_plots(infile, outdir, preprocdir=None, cameras=None):
+def make_plots(infile, basedir, preprocdir=None, cameras=None):
     '''Make plots for a single exposure
 
     Args:
         infile: input QA fits file with HDUs like PER_AMP, PER_FIBER, ...
-        outdir: write output HTML files to this directory
+        basedir: write output HTML to basedir/NIGHT/EXPID/
 
     Options:
         preprocdir: directory to where the "preproc-*-*.fits" are located. If
@@ -267,9 +267,6 @@ def make_plots(infile, outdir, preprocdir=None, cameras=None):
     from . import io
 
     log = desiutil.log.get_logger()
-    if not os.path.isdir(outdir):
-        log.info('Creating {}'.format(outdir))
-        os.makedirs(outdir, exist_ok=True)
 
     qadata = io.read_qa(infile)
     header = qadata['HEADER']
@@ -285,31 +282,37 @@ def make_plots(infile, outdir, preprocdir=None, cameras=None):
         night = int(dirnight)
         header['NIGHT'] = night
 
+    #- Create output exposures plot directory if needed
+    expdir = os.path.join(basedir, str(night), '{:08d}'.format(expid))
+    if not os.path.isdir(expdir):
+        log.info('Creating {}'.format(expdir))
+        os.makedirs(expdir, exist_ok=True)
+
     plot_components = dict()
     if 'PER_AMP' in qadata:
-        htmlfile = '{}/qa-amp-{:08d}.html'.format(outdir, expid)
+        htmlfile = '{}/qa-amp-{:08d}.html'.format(expdir, expid)
         pc = web_amp.write_amp_html(htmlfile, qadata['PER_AMP'], header)
         plot_components.update(pc)
         print('Wrote {}'.format(htmlfile))
 
     if 'PER_CAMFIBER' in qadata:
-        htmlfile = '{}/qa-camfiber-{:08d}.html'.format(outdir, expid)
+        htmlfile = '{}/qa-camfiber-{:08d}.html'.format(expdir, expid)
         pc = web_camfiber.write_camfiber_html(htmlfile, qadata['PER_CAMFIBER'], header)
         plot_components.update(pc)
         print('Wrote {}'.format(htmlfile))
 
     if 'PER_CAMERA' in qadata:
-        htmlfile = '{}/qa-camera-{:08d}.html'.format(outdir, expid)
+        htmlfile = '{}/qa-camera-{:08d}.html'.format(expdir, expid)
         pc = web_camera.write_camera_html(htmlfile, qadata['PER_CAMERA'], header)
         plot_components.update(pc)
         print('Wrote {}'.format(htmlfile))
 
-    htmlfile = '{}/qa-summary-{:08d}.html'.format(outdir, expid)
+    htmlfile = '{}/qa-summary-{:08d}.html'.format(expdir, expid)
     web_summary.write_summary_html(htmlfile, qadata, preprocdir)
     print('Wrote {}'.format(htmlfile))
 
-    #- TODO: this shouldn't go in the per-exposure directory
-    htmlfile = '{}/qa-lastexp.html'.format(outdir)
+    #- Note: last exposure goes in basedir, not expdir=basedir/NIGHT/EXPID
+    htmlfile = '{}/qa-lastexp.html'.format(basedir)
     web_lastexp.write_lastexp_html(htmlfile, qadata, preprocdir)
     print('Wrote {}'.format(htmlfile))
 
@@ -322,7 +325,7 @@ def make_plots(infile, outdir, preprocdir=None, cameras=None):
                 cameras += [os.path.basename(preprocfile).split('-')[1]]
         for camera in cameras:
             input = os.path.join(preprocdir, "preproc-{}-{:08d}.fits".format(camera, expid))
-            output = os.path.join(outdir, "preproc-{}-{:08d}-4x.html".format(camera, expid))
+            output = os.path.join(expdir, "preproc-{}-{:08d}-4x.html".format(camera, expid))
             plotimage.write_image_html(input, output, 4)
 
 def write_tables(indir, outdir):

--- a/py/qqa/script.py
+++ b/py/qqa/script.py
@@ -121,10 +121,10 @@ def main_monitor(options=None):
                 qarunner.run(indir=outdir, outfile=qafile, jsonfile=jsonfile)
 
                 print('Generating plots for {}/{}'.format(night, expid))
-                plotdir = '{}/{}/{}'.format(args.plotdir, night, expid)
-                if not os.path.isdir(plotdir) :
-                    os.makedirs(plotdir)
-                run.make_plots(infile=qafile, outdir=plotdir, preprocdir=outdir, cameras=cameras)
+                expdir = '{}/{}/{}'.format(args.plotdir, night, expid)
+                if not os.path.isdir(expdir) :
+                    os.makedirs(expdir)
+                run.make_plots(infile=qafile, basedir=args.plotdir, preprocdir=outdir, cameras=cameras)
 
                 run.write_tables(args.outdir, args.plotdir)
 
@@ -236,7 +236,7 @@ def main_qa(options=None):
 def main_plot(options=None):
     parser = argparse.ArgumentParser(usage = "{prog} plot [options]")
     parser.add_argument("-i", "--infile", type=str, nargs='*', required=True, help="input fits file name with qa outputs")
-    parser.add_argument("-o", "--outdir", type=str, help="output directory (including YEARMMDD/EXPID/)")
+    parser.add_argument("-o", "--outdir", type=str, help="output directory (not including YEARMMDD/EXPID/)")
 
     if options is None:
         options = sys.argv[2:]

--- a/py/qqa/script.py
+++ b/py/qqa/script.py
@@ -173,7 +173,8 @@ def main_run(options=None):
     qaresults = run.run_qa(args.outdir, outfile=qafile)
 
     print('{} Making plots'.format(time.strftime('%H:%M')))
-    run.make_plots(qafile, args.outdir, preprocdir=args.outdir, cameras=cameras)
+    basedir = os.path.dirname(os.path.dirname(os.path.abspath(args.outdir)))
+    run.make_plots(qafile, basedir, preprocdir=args.outdir, cameras=cameras)
 
     dt = (time.time() - time_start) / 60.0
     print('{} Done ({:.1f} min)'.format(time.strftime('%H:%M'), dt))
@@ -249,7 +250,7 @@ def main_plot(options=None):
         else:
             outdir = args.outdir
 
-        run.make_plots(infile, outdir, preprocdir=outdir)
+        run.make_plots(infile, outdir, preprocdir=os.path.dirname(infile))
         print("Done making plots for {}; wrote outputs to {}".format(args.infile, args.outdir))
 
 def main_tables(options=None):

--- a/py/qqa/webpages/amp.py
+++ b/py/qqa/webpages/amp.py
@@ -34,23 +34,21 @@ def write_amp_html(outfile, data, header):
 
     #- Generate the bokeh figure
     fig = plot_amp_qa(data, 'READNOISE', title='CCD Amplifier Read Noise',
-        qamin=1.5, qamax=4.0)
+        qamin=1.5, qamax=4.0, ymin=0, ymax=5.0)
     #- Convert that into the components to embed in the HTML
     script, div = components(fig)
     #- Save those in a dictionary to use later
     html_components['READNOISE'] = dict(script=script, div=div)
 
     #- Amplifier offset
-    fig = plot_amp_qa(data, 'BIAS', title='CCD Amplifier Overscan Bias Level',
-        palette=bokeh.palettes.all_palettes['GnBu'][6])
+    fig = plot_amp_qa(data, 'BIAS', title='CCD Amplifier Overscan Bias Level')
     script, div = components(fig)
     html_components['BIAS'] = dict(script=script, div=div)
 
     #- Cosmics rate
     fig = plot_amp_qa(data, 'COSMICS_RATE',
         title='CCD Amplifier cosmics per minute',
-        palette=bokeh.palettes.all_palettes['RdYlGn'][11][1:-1],
-        qamin=0, qamax=50)
+        qamin=10, qamax=50, ymin=0, ymax=60)
     script, div = components(fig)
     html_components['COSMICS_RATE'] = dict(script=script, div=div)
 

--- a/py/qqa/webpages/amp.py
+++ b/py/qqa/webpages/amp.py
@@ -7,7 +7,16 @@ from bokeh.embed import components
 from ..plots.amp import plot_amp_qa
 
 def write_amp_html(outfile, data, header):
-    '''TODO: document'''
+    '''Write CCD amp QA webpage
+
+    Args:
+        outfile: output HTML filename
+        data: PER_AMP QA table
+        header: dict-like data header with keys NIGHT, EXPID, PROGRAM
+
+    Returns:
+        html_components dict with keys 'script', 'div' from bokeh
+    '''
     
     night = header['NIGHT']
     expid = header['EXPID']

--- a/py/qqa/webpages/camfiber.py
+++ b/py/qqa/webpages/camfiber.py
@@ -55,7 +55,8 @@ def write_camfiber_html(outfile, data, header):
     return dict({})
 
 
-def write_fibernum_plots(data, template, outfile, header, ATTRIBUTES, CAMERAS, TITLESPERCAM, TOOLS):
+def write_fibernum_plots(data, template, outfile, header, ATTRIBUTES, CAMERAS,
+        TITLESPERCAM, TOOLS='pan,box_select,reset'):
     '''
     Args:
         data : fits file of per_camfiber data
@@ -88,7 +89,9 @@ def write_fibernum_plots(data, template, outfile, header, ATTRIBUTES, CAMERAS, T
     write_file = write_htmlfile(fn_camfiber_layout, template, outfile, header)
 
 
-def write_focalplate_plots(data, template, outfile, header, ATTRIBUTES, CAMERAS, PERCENTILES, TITLESPERCAM, TOOLS):    
+def write_focalplate_plots(data, template, outfile, header,
+        ATTRIBUTES, CAMERAS, PERCENTILES, TITLESPERCAM,
+        TOOLS='pan,box_select,reset'):
     '''
     Args:
         data : fits file of per_camfiber data

--- a/py/qqa/webpages/lastexp.py
+++ b/py/qqa/webpages/lastexp.py
@@ -59,6 +59,18 @@ def write_lastexp_html(outfile, data, qprocdir):
         script, div = components(fn_camfiber_layout)
         html_components['RAWFLUX'] = dict(script=script, div=div)
 
+    #- Calib flux
+    if flavor.upper() in ['SCIENCE']:
+        cameras = ['B', 'R', 'Z']  #- TODO: derive from data
+        cds = camfiber.get_cds(data['PER_CAMFIBER'], ['INTEG_CALIB_FLUX',], cameras)
+        figs_list = camfiber.plot_per_fibernum(cds, 'INTEG_CALIB_FLUX', cameras,
+            height=120, ymin=0, width=plot_width)
+        figs_list[0].title = bokeh.models.Title(text="Integrated Sky-sub Calib Flux Per Fiber")
+        fn_camfiber_layout = layout(figs_list)
+
+        script, div = components(fn_camfiber_layout)
+        html_components['CALIBFLUX'] = dict(script=script, div=div)
+
     #- Random Spectra
     if flavor.upper() in ['ARC', 'FLAT', 'SCIENCE'] and \
             'PER_CAMFIBER' in data and \

--- a/py/qqa/webpages/lastexp.py
+++ b/py/qqa/webpages/lastexp.py
@@ -1,0 +1,65 @@
+import numpy as np
+
+import jinja2
+import bokeh
+from bokeh.embed import components
+from bokeh.layouts import gridplot, layout
+
+from ..plots.amp import plot_amp_qa
+from . import camfiber
+
+def write_lastexp_html(outfile, data):
+    '''TODO: document'''
+    
+    header = data['HEADER']
+    night = header['NIGHT']
+    expid = header['EXPID']
+    flavor = header['FLAVOR'].rstrip()
+    if "PROGRAM" not in header :
+        program = "no program in header!"
+    else :
+        program = header['PROGRAM'].rstrip()
+    exptime = header['EXPTIME']
+
+    env = jinja2.Environment(
+        loader=jinja2.PackageLoader('qqa.webpages', 'templates')
+    )
+    template = env.get_template('lastexp.html')
+
+    html_components = dict(
+        bokeh_version=bokeh.__version__, exptime='{:.1f}'.format(exptime),
+        night=night, expid=expid, zexpid='{:08d}'.format(expid),
+        flavor=flavor, program=program,
+    )
+    
+    #- Add a basic set of PER_AMP QA plots
+    plot_components = dict()
+
+    #- CCD Rease Noise
+    fig = plot_amp_qa(data['PER_AMP'], 'READNOISE', title='CCD Amplifier Read Noise',
+        qamin=1.5, qamax=4.0)
+    script, div = components(fig)
+    html_components['READNOISE'] = dict(script=script, div=div)
+
+    #- Raw flux
+    if flavor.upper() in ['ARC', 'FLAT']:
+        cameras = ['B', 'R', 'Z']  #- TODO: derive from data
+        cds = camfiber.get_cds(data['PER_CAMFIBER'], ['INTEG_RAW_FLUX',], cameras)
+        figs_list = camfiber.plot_per_fibernum(cds, 'INTEG_RAW_FLUX', cameras) #, titles=TITLESPERCAM, tools=TOOLS)
+        fn_camfiber_layout = layout(figs_list)
+
+        script, div = components(fn_camfiber_layout)
+        html_components['RAWFLUX'] = dict(script=script, div=div)
+
+    #- TODO: Spectra
+    if flavor.upper() in ['ARC', 'FLAT', 'SCIENCE']:
+        pass
+
+    #- Combine template + components -> HTML
+    html = template.render(**html_components)
+
+    #- Write HTML text to the output file
+    with open(outfile, 'w') as fx:
+        fx.write(html)
+
+    return html_components

--- a/py/qqa/webpages/lastexp.py
+++ b/py/qqa/webpages/lastexp.py
@@ -38,11 +38,12 @@ def write_lastexp_html(outfile, data, qprocdir):
     #- Add a basic set of PER_AMP QA plots
     plot_components = dict()
 
-    plot_width = 700
+    plot_width = 500
 
     #- CCD Read Noise
     fig = plot_amp_qa(data['PER_AMP'], 'READNOISE', title='CCD Amplifier Read Noise',
-        qamin=1.5, qamax=4.0, ymin=0, ymax=5.0, plot_width=plot_width)
+        qamin=1.5, qamax=4.0, ymin=0, ymax=5.0,
+        plot_width=plot_width, plot_height=110)
     script, div = components(fig)
     html_components['READNOISE'] = dict(script=script, div=div)
 
@@ -52,7 +53,7 @@ def write_lastexp_html(outfile, data, qprocdir):
         cds = camfiber.get_cds(data['PER_CAMFIBER'], ['INTEG_RAW_FLUX',], cameras)
         figs_list = camfiber.plot_per_fibernum(cds, 'INTEG_RAW_FLUX', cameras,
             height=120, ymin=0, width=plot_width)
-        figs_list[0].title = bokeh.models.Title(text="Integrated raw flux per fiber")
+        figs_list[0].title = bokeh.models.Title(text="Integrated Raw Flux Per Fiber")
         fn_camfiber_layout = layout(figs_list)
 
         script, div = components(fn_camfiber_layout)
@@ -68,7 +69,7 @@ def write_lastexp_html(outfile, data, qprocdir):
         fibers = ','.join([str(tmp) for tmp in fibers])
 
         specfig = plot_spectra_input(os.path.dirname(qprocdir), expid, downsample,
-            fibers, height=350, width=plot_width)
+            fibers, height=300, width=plot_width*2)
         script, div = components(specfig)
         html_components['SPECTRA'] = dict(script=script, div=div, fibers=fibers)
 

--- a/py/qqa/webpages/lastexp.py
+++ b/py/qqa/webpages/lastexp.py
@@ -23,6 +23,10 @@ def write_lastexp_html(outfile, qadata, qprocdir):
     )
     template = env.get_template('lastexp.html')
 
+    #- Tell HTML to auto-reload upon change, using {staticdir}/live.js
+    plot_components['autoreload'] = True
+    plot_components['staticdir'] = 'cal_files'
+
     #- Combine template + components -> HTML
     html = template.render(**plot_components)
 

--- a/py/qqa/webpages/lastexp.py
+++ b/py/qqa/webpages/lastexp.py
@@ -38,9 +38,11 @@ def write_lastexp_html(outfile, data, qprocdir):
     #- Add a basic set of PER_AMP QA plots
     plot_components = dict()
 
-    #- CCD Rease Noise
+    plot_width = 700
+
+    #- CCD Read Noise
     fig = plot_amp_qa(data['PER_AMP'], 'READNOISE', title='CCD Amplifier Read Noise',
-        qamin=1.5, qamax=4.0)
+        qamin=1.5, qamax=4.0, ymin=0, ymax=5.0, plot_width=plot_width)
     script, div = components(fig)
     html_components['READNOISE'] = dict(script=script, div=div)
 
@@ -48,7 +50,8 @@ def write_lastexp_html(outfile, data, qprocdir):
     if flavor.upper() in ['ARC', 'FLAT']:
         cameras = ['B', 'R', 'Z']  #- TODO: derive from data
         cds = camfiber.get_cds(data['PER_CAMFIBER'], ['INTEG_RAW_FLUX',], cameras)
-        figs_list = camfiber.plot_per_fibernum(cds, 'INTEG_RAW_FLUX', cameras)        
+        figs_list = camfiber.plot_per_fibernum(cds, 'INTEG_RAW_FLUX', cameras,
+            height=120, ymin=0, width=plot_width)
         figs_list[0].title = bokeh.models.Title(text="Integrated raw flux per fiber")
         fn_camfiber_layout = layout(figs_list)
 
@@ -64,7 +67,8 @@ def write_lastexp_html(outfile, data, qprocdir):
         fibers = sorted(np.random.choice(data['PER_CAMFIBER']['FIBER'], size=nfib, replace=False))
         fibers = ','.join([str(tmp) for tmp in fibers])
 
-        specfig = plot_spectra_input(os.path.dirname(qprocdir), expid, downsample, fibers, height=500, width=1000)
+        specfig = plot_spectra_input(os.path.dirname(qprocdir), expid, downsample,
+            fibers, height=350, width=plot_width)
         script, div = components(specfig)
         html_components['SPECTRA'] = dict(script=script, div=div, fibers=fibers)
 

--- a/py/qqa/webpages/lastexp.py
+++ b/py/qqa/webpages/lastexp.py
@@ -14,9 +14,21 @@ from . import summary
 def write_lastexp_html(outfile, qadata, qprocdir):
     '''TODO: document'''
 
-    plotdir = os.path.dirname(outfile)
-    plot_components = summary.get_summary_plots(qadata, plotdir, qprocdir)
+    plot_components = summary.get_summary_plots(qadata, qprocdir)
     plot_components['qatype'] = 'summary'
+
+    #- Fix links to preproc images
+    #- default assumes they are in same dir as summary html, but that isn't
+    #- the case for this last exposure summary which is at the top level
+    #- TODO: this is fragile; could it be made better?
+    if 'READNOISE' in plot_components:
+        night = str(plot_components['night'])
+        zexpid = plot_components['zexpid']  #- zero padded str expid
+        plot_components['READNOISE']['script'] = \
+            plot_components['READNOISE']['script'].replace(
+                '{"url":"@name-4x.html"}',
+                '{"url":"'+night+'/'+zexpid+'/@name-4x.html"}'
+                )
 
     env = jinja2.Environment(
         loader=jinja2.PackageLoader('qqa.webpages', 'templates')

--- a/py/qqa/webpages/lastexp.py
+++ b/py/qqa/webpages/lastexp.py
@@ -12,7 +12,16 @@ from ..plots.spectra import plot_spectra_input
 from . import summary
 
 def write_lastexp_html(outfile, qadata, qprocdir):
-    '''TODO: document'''
+    '''Write summary webpage for the last exposure processed
+
+    Args:
+        outfile: output HTML filename
+        qadata: dict of QA tables, keys PER_AMP, PER_CAMFIBER, etc.
+        qprocdir: directory with qproc outputs
+
+    Returns:
+        html_components dict with keys 'script', 'div' from bokeh
+    '''
 
     plot_components = summary.get_summary_plots(qadata, qprocdir)
     plot_components['qatype'] = 'summary'

--- a/py/qqa/webpages/lastexp.py
+++ b/py/qqa/webpages/lastexp.py
@@ -9,87 +9,25 @@ from bokeh.layouts import gridplot, layout
 
 from ..plots.amp import plot_amp_qa
 from ..plots.spectra import plot_spectra_input
-from . import camfiber
+from . import summary
 
-def write_lastexp_html(outfile, data, qprocdir):
+def write_lastexp_html(outfile, qadata, qprocdir):
     '''TODO: document'''
-    
-    header = data['HEADER']
-    night = header['NIGHT']
-    expid = header['EXPID']
-    flavor = header['FLAVOR'].rstrip()
-    if "PROGRAM" not in header :
-        program = "no program in header!"
-    else :
-        program = header['PROGRAM'].rstrip()
-    exptime = header['EXPTIME']
+
+    plotdir = os.path.dirname(outfile)
+    plot_components = summary.get_summary_plots(qadata, plotdir, qprocdir)
+    plot_components['qatype'] = 'summary'
 
     env = jinja2.Environment(
         loader=jinja2.PackageLoader('qqa.webpages', 'templates')
     )
     template = env.get_template('lastexp.html')
 
-    html_components = dict(
-        bokeh_version=bokeh.__version__, exptime='{:.1f}'.format(exptime),
-        night=night, expid=expid, zexpid='{:08d}'.format(expid),
-        flavor=flavor, program=program,
-    )
-    
-    #- Add a basic set of PER_AMP QA plots
-    plot_components = dict()
-
-    plot_width = 500
-
-    #- CCD Read Noise
-    fig = plot_amp_qa(data['PER_AMP'], 'READNOISE', title='CCD Amplifier Read Noise',
-        qamin=1.5, qamax=4.0, ymin=0, ymax=5.0,
-        plot_width=plot_width, plot_height=110)
-    script, div = components(fig)
-    html_components['READNOISE'] = dict(script=script, div=div)
-
-    #- Raw flux
-    if flavor.upper() in ['ARC', 'FLAT']:
-        cameras = ['B', 'R', 'Z']  #- TODO: derive from data
-        cds = camfiber.get_cds(data['PER_CAMFIBER'], ['INTEG_RAW_FLUX',], cameras)
-        figs_list = camfiber.plot_per_fibernum(cds, 'INTEG_RAW_FLUX', cameras,
-            height=120, ymin=0, width=plot_width)
-        figs_list[0].title = bokeh.models.Title(text="Integrated Raw Flux Per Fiber")
-        fn_camfiber_layout = layout(figs_list)
-
-        script, div = components(fn_camfiber_layout)
-        html_components['RAWFLUX'] = dict(script=script, div=div)
-
-    #- Calib flux
-    if flavor.upper() in ['SCIENCE']:
-        cameras = ['B', 'R', 'Z']  #- TODO: derive from data
-        cds = camfiber.get_cds(data['PER_CAMFIBER'], ['INTEG_CALIB_FLUX',], cameras)
-        figs_list = camfiber.plot_per_fibernum(cds, 'INTEG_CALIB_FLUX', cameras,
-            height=120, ymin=0, width=plot_width)
-        figs_list[0].title = bokeh.models.Title(text="Integrated Sky-sub Calib Flux Per Fiber")
-        fn_camfiber_layout = layout(figs_list)
-
-        script, div = components(fn_camfiber_layout)
-        html_components['CALIBFLUX'] = dict(script=script, div=div)
-
-    #- Random Spectra
-    if flavor.upper() in ['ARC', 'FLAT', 'SCIENCE'] and \
-            'PER_CAMFIBER' in data and \
-            qprocdir is not None:
-        downsample = 4
-        nfib = min(5, len(data['PER_CAMFIBER']))
-        fibers = sorted(np.random.choice(data['PER_CAMFIBER']['FIBER'], size=nfib, replace=False))
-        fibers = ','.join([str(tmp) for tmp in fibers])
-
-        specfig = plot_spectra_input(os.path.dirname(qprocdir), expid, downsample,
-            fibers, height=300, width=plot_width*2)
-        script, div = components(specfig)
-        html_components['SPECTRA'] = dict(script=script, div=div, fibers=fibers)
-
     #- Combine template + components -> HTML
-    html = template.render(**html_components)
+    html = template.render(**plot_components)
 
     #- Write HTML text to the output file
     with open(outfile, 'w') as fx:
         fx.write(html)
 
-    return html_components
+    return plot_components

--- a/py/qqa/webpages/summary.py
+++ b/py/qqa/webpages/summary.py
@@ -17,7 +17,15 @@ from bokeh.embed import components
 from bokeh.layouts import gridplot, layout
 
 def get_summary_plots(qadata, qprocdir=None):
-    '''TODO: document'''
+    '''Get bokeh summary plots
+
+    Args:
+        qadata: dict of QA tables, keys PER_AMP, PER_CAMFIBER, etc.
+        qprocdir: directory with qproc output (qframe-*.fits etc)
+
+    Returns:
+        dict of html_components to embed in a summary webpage
+    '''
 
     header = qadata['HEADER']
     night = header['NIGHT']
@@ -92,6 +100,9 @@ def write_summary_html(outfile, qadata, qprocdir):
         outfile: output HTML file
         qadata : dict of QA tables, keys PER_AMP, PER_CAMFIBER, etc.
         qprocdir : directory containing qproc outputs (qframe*.fits, etc.)
+
+    Returns:
+        None
     """
 
     plot_components = get_summary_plots(qadata, qprocdir)
@@ -119,7 +130,10 @@ def update_camfib_pc(pc, qadata,
                      titlespercam={'B':{'INTEG_RAW_FLUX':'Integrated Raw Counts', 'MEDIAN_RAW_SNR':'Median Raw S/N'}}, 
                      tools='pan,box_zoom,reset',
                     ):
-    
+    '''
+    TODO: document
+    '''
+
     if 'PER_CAMFIBER' not in qadata:
         return
     

--- a/py/qqa/webpages/summary.py
+++ b/py/qqa/webpages/summary.py
@@ -2,27 +2,101 @@
 Pages summarizing QA results
 """
 
+import os
 import numpy as np
 import jinja2
 
 from .. import io
-from ..webpages.camfiber import get_cds
 from ..plots.camfiber import plot_per_fibernum
+from ..plots.amp import plot_amp_qa
+from ..plots.spectra import plot_spectra_input
+from . import camfiber
 
+import bokeh
 from bokeh.embed import components
-from bokeh.layouts import layout
+from bokeh.layouts import gridplot, layout
 
-def write_summary_html(outfile, qadata, plot_components):
+def get_summary_plots(qadata, plotdir, qprocdir):
+    '''TODO: document'''
+
+    header = qadata['HEADER']
+    night = header['NIGHT']
+    expid = header['EXPID']
+    flavor = header['FLAVOR'].rstrip()
+    if "PROGRAM" not in header :
+        program = "no program in header!"
+    else :
+        program = header['PROGRAM'].rstrip()
+    exptime = header['EXPTIME']
+
+    html_components = dict(
+        bokeh_version=bokeh.__version__, exptime='{:.1f}'.format(exptime),
+        night=night, expid=expid, zexpid='{:08d}'.format(expid),
+        flavor=flavor, program=program,
+    )
+
+    plot_width = 500
+
+    #- CCD Read Noise
+    fig = plot_amp_qa(qadata['PER_AMP'], 'READNOISE', title='CCD Amplifier Read Noise',
+        qamin=1.5, qamax=4.0, ymin=0, ymax=5.0,
+        plot_width=plot_width, plot_height=110)
+    script, div = components(fig)
+    html_components['READNOISE'] = dict(script=script, div=div)
+
+    #- Raw flux
+    if flavor.upper() in ['ARC', 'FLAT']:
+        cameras = ['B', 'R', 'Z']  #- TODO: derive from data
+        cds = camfiber.get_cds(qadata['PER_CAMFIBER'], ['INTEG_RAW_FLUX',], cameras)
+        figs_list = camfiber.plot_per_fibernum(cds, 'INTEG_RAW_FLUX', cameras,
+            height=120, ymin=0, width=plot_width)
+        figs_list[0].title = bokeh.models.Title(text="Integrated Raw Flux Per Fiber")
+        fn_camfiber_layout = layout(figs_list)
+
+        script, div = components(fn_camfiber_layout)
+        html_components['RAWFLUX'] = dict(script=script, div=div)
+
+    #- Calib flux
+    if flavor.upper() in ['SCIENCE']:
+        cameras = ['B', 'R', 'Z']  #- TODO: derive from data
+        cds = camfiber.get_cds(qadata['PER_CAMFIBER'], ['INTEG_CALIB_FLUX',], cameras)
+        figs_list = camfiber.plot_per_fibernum(cds, 'INTEG_CALIB_FLUX', cameras,
+            height=120, ymin=0, width=plot_width)
+        figs_list[0].title = bokeh.models.Title(text="Integrated Sky-sub Calib Flux Per Fiber")
+        fn_camfiber_layout = layout(figs_list)
+
+        script, div = components(fn_camfiber_layout)
+        html_components['CALIBFLUX'] = dict(script=script, div=div)
+
+    #- Random Spectra
+    if flavor.upper() in ['ARC', 'FLAT', 'SCIENCE'] and \
+            'PER_CAMFIBER' in qadata and \
+            qprocdir is not None:
+        downsample = 4
+        nfib = min(5, len(qadata['PER_CAMFIBER']))
+        fibers = sorted(np.random.choice(qadata['PER_CAMFIBER']['FIBER'], size=nfib, replace=False))
+        fibers = ','.join([str(tmp) for tmp in fibers])
+
+        specfig = plot_spectra_input(os.path.dirname(qprocdir), expid, downsample,
+            fibers, height=300, width=plot_width*2)
+        script, div = components(specfig)
+        html_components['SPECTRA'] = dict(script=script, div=div, fibers=fibers)
+
+    return html_components
+
+def write_summary_html(outfile, qadata, qprocdir):
     """Write the most important QA plots to outfile
-    
+
     Args:
         outfile: output HTML file
-        qadata : fits file of data for a single exposure
-        plot_components: dictionary with keys night, expid, flavor, program,
-            and QA plots
-    
-    changes plot_components['qatype'] to 'summary'
+        qadata : dict of QA tables, keys PER_AMP, PER_CAMFIBER, etc.
+        qprocdir : directory containing qproc outputs (qframe*.fits, etc.)
     """
+
+    plotdir = os.path.dirname(outfile)
+    plot_components = get_summary_plots(qadata, plotdir, qprocdir)
+    plot_components['qatype'] = 'summary'
+
     update_camfib_pc(plot_components, qadata)
 
     env = jinja2.Environment(
@@ -32,7 +106,6 @@ def write_summary_html(outfile, qadata, plot_components):
         
     #- TODO: Add links to whatever detailed QA pages exist
     
-    plot_components['qatype'] = 'summary'
     html = template.render(**plot_components)
 
     #- Write HTML text to the output file
@@ -51,7 +124,7 @@ def update_camfib_pc(pc, qadata,
         return
     
     data = qadata['PER_CAMFIBER']
-    cds = get_cds(data, metrics, cameras)
+    cds = camfiber.get_cds(data, metrics, cameras)
 
     fibernum_gridlist = []
     for attr in metrics:

--- a/py/qqa/webpages/summary.py
+++ b/py/qqa/webpages/summary.py
@@ -16,7 +16,7 @@ import bokeh
 from bokeh.embed import components
 from bokeh.layouts import gridplot, layout
 
-def get_summary_plots(qadata, plotdir, qprocdir):
+def get_summary_plots(qadata, qprocdir=None):
     '''TODO: document'''
 
     header = qadata['HEADER']
@@ -77,7 +77,8 @@ def get_summary_plots(qadata, plotdir, qprocdir):
         fibers = sorted(np.random.choice(qadata['PER_CAMFIBER']['FIBER'], size=nfib, replace=False))
         fibers = ','.join([str(tmp) for tmp in fibers])
 
-        specfig = plot_spectra_input(os.path.dirname(qprocdir), expid, downsample,
+        nightdir = os.path.dirname(os.path.normpath(qprocdir))
+        specfig = plot_spectra_input(nightdir, expid, downsample,
             fibers, height=300, width=plot_width*2)
         script, div = components(specfig)
         html_components['SPECTRA'] = dict(script=script, div=div, fibers=fibers)
@@ -93,8 +94,7 @@ def write_summary_html(outfile, qadata, qprocdir):
         qprocdir : directory containing qproc outputs (qframe*.fits, etc.)
     """
 
-    plotdir = os.path.dirname(outfile)
-    plot_components = get_summary_plots(qadata, plotdir, qprocdir)
+    plot_components = get_summary_plots(qadata, qprocdir)
     plot_components['qatype'] = 'summary'
 
     update_camfib_pc(plot_components, qadata)

--- a/py/qqa/webpages/tables.py
+++ b/py/qqa/webpages/tables.py
@@ -188,7 +188,8 @@ def write_exposures_tables(indir,outdir, exposures, nights=None):
 
             explist.append(expinfo)
 
-        html = template.render(night=night, exposures=explist, autoreload=True)
+        html = template.render(night=night, exposures=explist, autoreload=True,
+            staticdir='../cal_files')
         outfile = os.path.join(outdir, str(night), 'exposures.html')
         with open(outfile, 'w') as fx:
             fx.write(html)

--- a/py/qqa/webpages/templates/base.html
+++ b/py/qqa/webpages/templates/base.html
@@ -115,6 +115,11 @@ ul.navigationbar li a.current_page {
   background-color: DarkSlateBlue;
 }
 
+.flex-container {
+  display: flex;
+  flex-wrap: wrap;
+}
+
 </style>
 </head>
 

--- a/py/qqa/webpages/templates/base.html
+++ b/py/qqa/webpages/templates/base.html
@@ -10,12 +10,12 @@
     href="https://cdn.pydata.org/bokeh/release/bokeh-tables-{{ bokeh_version }}.min.css"
     rel="stylesheet" type="text/css"
 >
-<script src="https://cdn.pydata.org/bokeh/release/bokeh-{{ bokeh_version }}.min.js" defer></script>
-<script src="https://cdn.pydata.org/bokeh/release/bokeh-tables-{{ bokeh_version }}.min.js" defer></script>
+<script src="https://cdn.pydata.org/bokeh/release/bokeh-{{ bokeh_version }}.min.js"></script>
+<script src="https://cdn.pydata.org/bokeh/release/bokeh-tables-{{ bokeh_version }}.min.js"></script>
 {% endif %}
 
 {% if autoreload %}
-<script type="text/javascript" src="{{ staticdir }}/live.js#html" defer></script>
+<script type="text/javascript" src="{{ staticdir }}/live.js#html"></script>
 {% endif %}
 
 <head>

--- a/py/qqa/webpages/templates/base.html
+++ b/py/qqa/webpages/templates/base.html
@@ -10,12 +10,12 @@
     href="https://cdn.pydata.org/bokeh/release/bokeh-tables-{{ bokeh_version }}.min.css"
     rel="stylesheet" type="text/css"
 >
-<script src="https://cdn.pydata.org/bokeh/release/bokeh-{{ bokeh_version }}.min.js"></script>
-<script src="https://cdn.pydata.org/bokeh/release/bokeh-tables-{{ bokeh_version }}.min.js"></script>
+<script src="https://cdn.pydata.org/bokeh/release/bokeh-{{ bokeh_version }}.min.js" defer></script>
+<script src="https://cdn.pydata.org/bokeh/release/bokeh-tables-{{ bokeh_version }}.min.js" defer></script>
 {% endif %}
 
 {% if autoreload %}
-<script type="text/javascript" src="../cal_files/live.js#html"></script>
+<script type="text/javascript" src="{{ staticdir }}/live.js#html" defer></script>
 {% endif %}
 
 <head>

--- a/py/qqa/webpages/templates/exposures.html
+++ b/py/qqa/webpages/templates/exposures.html
@@ -6,6 +6,7 @@
   <li><a id="next">next</a></li>
   <li><a id="prev">prev</a></li>
   <li><a href="../nights.html">calendar</a></li>
+  <li><a href="../qa-lastexp.html">latest</a></li>
 </ul>
 
 {# Each plot is wrapped in if/endif for robustness against missing plots #}
@@ -28,6 +29,12 @@
 </script>
 <script src="../nightlinks.js"></script>
 
+{#
+<p>
+<a href="../qa-lastexp.html">Summary of latest exposure</a> (auto-updating)
+</p>
+#}
+
 <table>
 <tr>
   <th colspan="4">Metadata</th>
@@ -45,7 +52,7 @@
   <th>Exp</th>
 </tr>
 
-{% for exp in exposures %}
+{% for exp in exposures|reverse %}
 <tr>
   <td>{{ exp.night }}</td>
   <td><a href="{{ exp.link }}">{{ exp.expid }}</a></td>

--- a/py/qqa/webpages/templates/lastexp.html
+++ b/py/qqa/webpages/templates/lastexp.html
@@ -2,7 +2,7 @@
 
 {% block body %}
 
-<h3>Night {{ night }} Exposure {{ expid }}</h3>
+<h3>Last exposure: Night {{ night }} Exposure {{ expid }}</h3>
 <p>{{ exptime }} second {{ flavor }} ({{ program }})</p>
 
 {# Each plot is wrapped in if/endif for robustness against missing plots #}

--- a/py/qqa/webpages/templates/lastexp.html
+++ b/py/qqa/webpages/templates/lastexp.html
@@ -2,8 +2,9 @@
 
 {% block body %}
 
-<h3>Last exposure: Night {{ night }} Exposure {{ expid }}</h3>
-<p>{{ exptime }} second {{ flavor }} ({{ program }})</p>
+<p>
+Last exposure {{ night }}/{{ expid }}: {{ exptime }} sec {{ flavor }} ({{ program }})
+</p>
 
 {# Each plot is wrapped in if/endif for robustness against missing plots #}
 

--- a/py/qqa/webpages/templates/lastexp.html
+++ b/py/qqa/webpages/templates/lastexp.html
@@ -1,10 +1,30 @@
 {% extends "base.html" %}
 
+{% block navigation %}
+<ul class="navigationbar">
+  <li style="float:left"><a>Last Exposure: {{ night }}/{{ expid }}</a></li>
+  <li class="dropdown"><a id="camfiber" href = "{{ night }}/{{ zexpid }}/qa-camfiber-{{ zexpid }}.html">camfiber</a>
+      <ul class="dropdown-content">
+        <a id="camfiber" href="{{ night }}/{{ zexpid }}/qa-camfiber-{{ zexpid }}.html">fibernum</a>
+        <a id="focalplate" href="{{ night }}/{{ zexpid }}/qa-camfiber-{{ zexpid }}-focalplate_plots.html">focalplate</a>
+      </ul>
+  </li>
+  <li><a id="camera" href="{{ night }}/{{ zexpid }}/qa-camera-{{ zexpid }}.html">camera</a></li>
+  <li><a id="amp" href="{{ night }}/{{ zexpid }}/qa-amp-{{ zexpid }}.html">amp</a></li>
+  <li><a id="summary" href="{{ night }}/{{ zexpid }}/qa-summary-{{ zexpid }}.html">summary</a></li>
+  <li><a id="exposures" href="{{ night }}/exposures.html">exposures</a></li>
+  <li><a id="nights" href = "nights.html">nights</a></li>
+</ul>
+<p>{{ exptime }} second {{ flavor }} ({{ program }})</p>
+{% endblock %}
+
 {% block body %}
 
+{#
 <p>
 Last exposure {{ night }}/{{ expid }}: {{ exptime }} sec {{ flavor }} ({{ program }})
 </p>
+#}
 
 {# Each plot is wrapped in if/endif for robustness against missing plots #}
 

--- a/py/qqa/webpages/templates/lastexp.html
+++ b/py/qqa/webpages/templates/lastexp.html
@@ -1,0 +1,22 @@
+{% extends "base.html" %}
+
+{% block body %}
+
+{# Each plot is wrapped in if/endif for robustness against missing plots #}
+
+{% if READNOISE %}
+    <h3>CCD Read Noise</h3>
+    <div>{{ READNOISE.script }} {{ READNOISE.div }}</div>
+{% endif %}
+
+{% if RAWFLUX %}
+    <h3>Per-fiber integrated raw counts</h3>
+    <div>{{ RAWFLUX.script }} {{ RAWFLUX.div }}</div>
+{% endif %}
+
+{% if CALIBFLUX %}
+    <h3>Per-fiber sky-subtracted flux-calibrated integrated flux</h3>
+    <div>{{ CALIBFLUX.script }} {{ CALIBFLUX.div }}</div>
+{% endif %}
+
+{% endblock %}

--- a/py/qqa/webpages/templates/lastexp.html
+++ b/py/qqa/webpages/templates/lastexp.html
@@ -2,21 +2,29 @@
 
 {% block body %}
 
+<h3>Night {{ night }} Exposure {{ expid }}</h3>
+<p>{{ exptime }} second {{ flavor }} ({{ program }})</p>
+
 {# Each plot is wrapped in if/endif for robustness against missing plots #}
 
 {% if READNOISE %}
-    <h3>CCD Read Noise</h3>
+    {# <h3>CCD Read Noise</h3> #}
     <div>{{ READNOISE.script }} {{ READNOISE.div }}</div>
 {% endif %}
 
 {% if RAWFLUX %}
-    <h3>Per-fiber integrated raw counts</h3>
+    {# <h3>Per-fiber integrated raw counts</h3> #}
     <div>{{ RAWFLUX.script }} {{ RAWFLUX.div }}</div>
 {% endif %}
 
 {% if CALIBFLUX %}
-    <h3>Per-fiber sky-subtracted flux-calibrated integrated flux</h3>
+    {# <h3>Per-fiber sky-subtracted flux-calibrated integrated flux</h3> #}
     <div>{{ CALIBFLUX.script }} {{ CALIBFLUX.div }}</div>
+{% endif %}
+
+{% if SPECTRA %}
+    {# <h3>Spectra {{ SPECTRA.fibers }}</h3> #}
+    <div>{{ SPECTRA.script }} {{ SPECTRA.div }}</div>
 {% endif %}
 
 {% endblock %}

--- a/py/qqa/webpages/templates/lastexp.html
+++ b/py/qqa/webpages/templates/lastexp.html
@@ -7,24 +7,24 @@
 
 {# Each plot is wrapped in if/endif for robustness against missing plots #}
 
+<div class="flex-container">
+
 {% if READNOISE %}
-    {# <h3>CCD Read Noise</h3> #}
     <div>{{ READNOISE.script }} {{ READNOISE.div }}</div>
 {% endif %}
 
 {% if RAWFLUX %}
-    {# <h3>Per-fiber integrated raw counts</h3> #}
     <div>{{ RAWFLUX.script }} {{ RAWFLUX.div }}</div>
 {% endif %}
 
 {% if CALIBFLUX %}
-    {# <h3>Per-fiber sky-subtracted flux-calibrated integrated flux</h3> #}
     <div>{{ CALIBFLUX.script }} {{ CALIBFLUX.div }}</div>
 {% endif %}
 
 {% if SPECTRA %}
-    {# <h3>Spectra {{ SPECTRA.fibers }}</h3> #}
     <div>{{ SPECTRA.script }} {{ SPECTRA.div }}</div>
 {% endif %}
+
+</div>
 
 {% endblock %}

--- a/py/qqa/webpages/templates/qabase.html
+++ b/py/qqa/webpages/templates/qabase.html
@@ -2,10 +2,10 @@
 
 {% block navigation %}
 <ul class="navigationbar">
-  <li style="float:left"><a id="nights" href = "../../nights.html">nights</a></li>
   <li style="float:left"><a>QA {{ night }}/{{ expid }}</a></li>
   <li style="float:left"><a id="prev">prev</a></li>
   <li style="float:left"><a id="next">next</a></li>
+  <li style="float:left"><a href="../../qa-lastexp.html">last</a></li>
   <li><a id="spectro">spectro</a></li>
   <li class="dropdown"><a id="camfiber" href = "qa-camfiber-{{ zexpid }}.html">camfiber</a>
       <ul class="dropdown-content">
@@ -18,6 +18,7 @@
   <li><a id="amp" href="qa-amp-{{ zexpid }}.html">amp</a></li>
   <li><a id="summary" href="qa-summary-{{ zexpid }}.html">summary</a></li>
   <li><a id="exposures" href="../exposures.html">exposures</a></li>
+  <li><a id="nights" href = "../../nights.html">nights</a></li>
 </ul>
 <p>{{ exptime }} second {{ flavor }} ({{ program }})</p>
 

--- a/py/qqa/webpages/templates/summary.html
+++ b/py/qqa/webpages/templates/summary.html
@@ -4,16 +4,24 @@
 
 {# Each plot is wrapped in if/endif for robustness against missing plots #}
 
-<h3>Amp Metrics</h3>
+<div class="flex-container">
+
 {% if READNOISE %}
     <div>{{ READNOISE.script }} {{ READNOISE.div }}</div>
 {% endif %}
 
-<h3>Camfiber Metrics</h3>
-{% if CAMFIBER_METRICS %}
-    <div>
-        {{ CAMFIBER_METRICS.script }} {{ CAMFIBER_METRICS.div }}
-    </div>
+{% if RAWFLUX %}
+    <div>{{ RAWFLUX.script }} {{ RAWFLUX.div }}</div>
 {% endif %}
+
+{% if CALIBFLUX %}
+    <div>{{ CALIBFLUX.script }} {{ CALIBFLUX.div }}</div>
+{% endif %}
+
+{% if SPECTRA %}
+    <div>{{ SPECTRA.script }} {{ SPECTRA.div }}</div>
+{% endif %}
+
+</div>
 
 {% endblock %}


### PR DESCRIPTION
This PR adds an auto-updating summary page of the latest exposure at {url}/qa-lastexp.html.  arc, flat, and science exposures show CCD read noise, integrated flux per fiber, and 5 randomly selected spectra.  zero and dark exposures show just the CCD readnoise.  And example flat exposure is:
<img width="858" alt="image" src="https://user-images.githubusercontent.com/218471/59991913-0a62f500-95fe-11e9-9084-cf9981376fd3.png">

The auto-updating exposures table is also reversed so that the latest exposure is always on the top, and the "latest" link in the navigation bar will take you to the auto-updating latest exposure page instead of the links to a specific exposure.

I've tested this on my laptop using qqa_web_app.py to serve the pages, and at NERSC using Apache.  I'd like to merge this Monday morning so that @julienguy can update it and use it at KPNO this week.  Additional testers/review welcome, but I'll self merge if needed.

Bonus: this example is from the March spectrograph functional verification and shows the high-frequency ringing in the flat lamp spectra due to the accidental etalon from the neutral density filter.  This has been fixed now, and this QA page can help catch similar problems in the future if they arise.
