### PR TITLE
Timeseries redesign

### DIFF
--- a/py/qqa/plots/timeseries.py
+++ b/py/qqa/plots/timeseries.py
@@ -88,7 +88,7 @@ def generate_timeseries(data_dir, start_date, end_date, hdu, aspect):
         group_by_list.remove("CAM")
         for cam in ["B", "R", "Z"]:
             cam_table = table_by_amp[table_by_amp["CAM"] == cam]
-            fig = bk.figure(title="CAM "+cam, toolbar_location="above", plot_height = 200, plot_width = 500)
+            fig = bk.figure(title="CAM "+cam, toolbar_location="above", plot_height = 200, plot_width = 700)
             max_y=None
             min_y=None
             for row in cam_table:
@@ -147,7 +147,7 @@ def generate_timeseries(data_dir, start_date, end_date, hdu, aspect):
         fig = gridplot([[i] for i in cam_figs], sizing_mode="fixed")
 
     else:
-        fig = bk.figure(toolbar_location="above", plot_height = 300, plot_width = 750)
+        fig = bk.figure(toolbar_location="above", plot_height = 300, plot_width = 800)
         for row in table_by_amp:
             length = len(row["EXPID"])
             data=dict(

--- a/py/qqa/plots/timeseries.py
+++ b/py/qqa/plots/timeseries.py
@@ -3,7 +3,7 @@ import numpy as np
 import os, re, sys
 import fitsio
 import bokeh.plotting as bk
-from bokeh.layouts import column
+from bokeh.layouts import gridplot
 from bokeh.models import TapTool as TapTool
 from bokeh.models import OpenURL, ColumnDataSource, HoverTool, CustomJS
 from qqa.qa.base import QA
@@ -82,6 +82,7 @@ def generate_timeseries(data_dir, start_date, end_date, hdu, aspect):
         table_by_amp = table.group_by(group_by_list).groups.aggregate(list)
 
     cam_figs = []
+    first = None
     if "CAM" in table_by_amp.colnames:
         colors = {"B":"blue", "R":"red", "Z":"green"}
         group_by_list.remove("CAM")
@@ -110,8 +111,8 @@ def generate_timeseries(data_dir, start_date, end_date, hdu, aspect):
 
                 if min(row[aspect]) < min_y:
                     min_y = min(row[aspect])
-                fig.line("EXPID", "aspect_values", source=source, alpha=0.5, color=colors[cam], name="lines", nonselection_alpha=1, selection_alpha=1)
-                fig.circle("EXPID", "aspect_values", size=7.5, source=source, alpha=0.5, color=colors[cam], name="dots", nonselection_fill_alpha=1,)
+                fig.line("EXPID", "aspect_values", source=source, alpha=0.5, color=colors[cam], name="lines", nonselection_alpha=1, selection_alpha=0.5)
+                fig.circle("EXPID", "aspect_values", source=source, alpha=0.5, color=colors[cam], name="dots", nonselection_fill_alpha=1,)
 
             tooltips = tooltips=[
                 ("NIGHT", "@NIGHT"),
@@ -138,8 +139,12 @@ def generate_timeseries(data_dir, start_date, end_date, hdu, aspect):
             fig.add_tools(tap)
             fig.add_tools(hover_follow)
             cam_figs += [fig]
+            if first is None:
+                first = fig
+            else:
+                fig.x_range=first.x_range
 
-        fig = column(cam_figs)
+        fig = gridplot([[i] for i in cam_figs], sizing_mode="fixed")
 
     else:
         fig = bk.figure(toolbar_location="above", plot_height = 300, plot_width = 750)

--- a/py/qqa/webpages/templates/timeseries.html
+++ b/py/qqa/webpages/templates/timeseries.html
@@ -1,5 +1,14 @@
 {% extends "base.html" %}
 
+{% block navigation %}
+
+<ul class="navigationbar">
+  <li style="float:left"><a id="nights" href = "../../../../../nights.html">nights</a></li>
+  <li style="float:left"><a>{{attribute}} Timeseries from {{start}} to {{end}} (inclusive)</a></li>
+</ul>
+
+{% endblock %}
+
 {% block body %}
 
 {# Rendering arguments: attribute, start, end, timeseries(.script, .div) #}
@@ -21,25 +30,15 @@ input {
   margin-left: 10px;
 }
 
-.container{
-  display: flex;
+header {
+  font-weight:bold;
+  font-size: 25px;
 }
-.flex-item{
-  flex-grow: 1;
-}
+
 </style>
 
-<button onclick='
-  var url = "../../../../../nights.html"
-
-  window.open(url, "_top")
-'>Nights</button>
-
-<header><strong>{{attribute}} Timeseries from {{start}} to {{end}} (inclusive)</strong></header>
-
-<div class="container">
 {% if timeseries %}
-    <div class=flex-item>{{ timeseries.script }} {{ timeseries.div }}</div>
+    <div>{{ timeseries.script }} {{ timeseries.div }}</div>
 {% endif %}
 <script src="../../../../cal_files/jquery_min.js"></script>
 <link rel="stylesheet" href="//code.jquery.com/ui/1.12.1/themes/base/jquery-ui.css">
@@ -50,7 +49,7 @@ input {
     $( "#end" ).datepicker({ dateFormat: 'yymmdd' });
   } );
 </script>
-<div class=flex-item>
+<div>
 <label>start date: <input type="number" id = "start" value = {{start}}></label>
 <label>end date: <input type="number" id = "end" value = {{end}}></label>
 <label>hdu:
@@ -79,7 +78,6 @@ input {
   var url = "../../../" + document.getElementById("start").value + "/" + document.getElementById("end").value + "/" +  document.getElementById("hdu").value + "/" +  document.getElementById("attribute").value
   window.open(url, "_top")
 '>Generate Timeseries</button>
-</div>
 <script>
 function changed(new_val) {
   {% for hdu_ in dropdown_hdu %}

--- a/py/qqa/webpages/templates/timeseries_input.html
+++ b/py/qqa/webpages/templates/timeseries_input.html
@@ -1,4 +1,16 @@
-<html>
+{% extends "base.html" %}
+
+{% block navigation %}
+
+<ul class="navigationbar">
+  <li style="float:left"><a id="nights" href = "../nights.html">nights</a></li>
+  <li style="float:left"><a>Timeseries Generator</a></li>
+</ul>
+
+{% endblock %}
+
+{% block body %}
+<br>
 <script src="../../../../cal_files/jquery_min.js"></script>
 <link rel="stylesheet" href="//code.jquery.com/ui/1.12.1/themes/base/jquery-ui.css">
 <script src="https://code.jquery.com/ui/1.12.1/jquery-ui.js"></script>
@@ -25,12 +37,6 @@ input {
   margin-left: 10px;
 }
 </style>
-
-<button onclick='
-  var url = "../nights.html"
-
-  window.open(url, "_top")
-'>Nights</button>
 
 <label>start date: <input type="number" id = "start"></label>
 <label>end date: <input type="number" id = "end"></label>
@@ -68,3 +74,5 @@ function changed(new_val) {
   {% endfor %}
 }
 </script>
+
+{% endblock %}


### PR DESCRIPTION
Redesigned the timeseries page:
    - used smaller symbols
    -added linked horizontal zooming/panning
    -made plots longer
    -moved the inputs to below the plots
    -added nav-bar to contain title and return-to-nights button

Addresses #76. 
