### PR TITLE
Skipping empty directories in qqa-monitor

### DIFF
--- a/py/qqa/run.py
+++ b/py/qqa/run.py
@@ -74,8 +74,8 @@ def find_latest_expdir(basedir, processed):
                 fits_fz_exists = np.any([re.match('desi-\d{8}.fits.fz', file) for file in os.listdir(expdir)])
                 if re.match('\d{8}', dirname) and os.path.isdir(expdir) and fits_fz_exists:
                     return expdir
-            else:
-                return None  #- no basename/YEARMMDD/EXPID directory was found
+            #else:
+            #    return None  #- no basename/YEARMMDD/EXPID directory was found
     else:
         return None  #- no basename/YEARMMDD directory was found
 

--- a/py/qqa/run.py
+++ b/py/qqa/run.py
@@ -51,6 +51,8 @@ def find_unprocessed_expdir(datadir, outdir):
                         qafile = os.path.join(outdir, night, expid, 'qa-{}.fits'.format(expid))
                         if not os.path.exists(qafile):
                             return expdir
+                    else:
+                        print('Skipping {}/{} with no desi*.fits.fz data'.format(night, expid))
 
     return None
 
@@ -67,13 +69,17 @@ def find_latest_expdir(basedir, processed):
     for dirname in sorted(os.listdir(basedir), reverse=True):
         nightdir = os.path.join(basedir, dirname)
         if re.match('20\d{6}', dirname) and os.path.isdir(nightdir):
+            night = dirname
             for dirname in sorted(os.listdir(nightdir)):
+                expid = dirname
                 expdir = os.path.join(nightdir, dirname)
                 if expdir in processed:
                     continue
                 fits_fz_exists = np.any([re.match('desi-\d{8}.fits.fz', file) for file in os.listdir(expdir)])
                 if re.match('\d{8}', dirname) and os.path.isdir(expdir) and fits_fz_exists:
                     return expdir
+                else:
+                    print('Skipping {}/{} with no desi*.fits.fz data'.format(night, expid))
             #else:
             #    return None  #- no basename/YEARMMDD/EXPID directory was found
     else:

--- a/py/qqa/run.py
+++ b/py/qqa/run.py
@@ -67,21 +67,17 @@ def find_latest_expdir(basedir, processed):
     for dirname in sorted(os.listdir(basedir), reverse=True):
         nightdir = os.path.join(basedir, dirname)
         if re.match('20\d{6}', dirname) and os.path.isdir(nightdir):
-            break
+            for dirname in sorted(os.listdir(nightdir)):
+                expdir = os.path.join(nightdir, dirname)
+                if expdir in processed:
+                    continue
+                fits_fz_exists = np.any([re.match('desi-\d{8}.fits.fz', file) for file in os.listdir(expdir)])
+                if re.match('\d{8}', dirname) and os.path.isdir(expdir) and fits_fz_exists:
+                    return expdir
+            else:
+                return None  #- no basename/YEARMMDD/EXPID directory was found
     else:
         return None  #- no basename/YEARMMDD directory was found
-
-    for dirname in sorted(os.listdir(nightdir)):
-        expdir = os.path.join(nightdir, dirname)
-        if expdir in processed:
-            continue
-        fits_fz_exists = np.any([re.match('desi-\d{8}.fits.fz', file) for file in os.listdir(expdir)])
-        if re.match('\d{8}', dirname) and os.path.isdir(expdir) and fits_fz_exists:
-            break
-    else:
-        return None  #- no basename/YEARMMDD/EXPID directory was found
-
-    return expdir
 
 def which_cameras(rawfile):
     '''

--- a/py/qqa/run.py
+++ b/py/qqa/run.py
@@ -46,9 +46,11 @@ def find_unprocessed_expdir(datadir, outdir):
             for expid in sorted(os.listdir(nightdir)):
                 expdir = os.path.join(nightdir, expid)
                 if re.match('\d{8}', expid) and os.path.isdir(expdir):
-                    qafile = os.path.join(outdir, night, expid, 'qa-{}.fits'.format(expid))
-                    if not os.path.exists(qafile):
-                        return expdir
+                    fits_fz_exists = np.any([re.match('desi-\d{8}.fits.fz', file) for file in os.listdir(expdir)])
+                    if fits_fz_exists:
+                        qafile = os.path.join(outdir, night, expid, 'qa-{}.fits'.format(expid))
+                        if not os.path.exists(qafile):
+                            return expdir
 
     return None
 
@@ -73,7 +75,8 @@ def find_latest_expdir(basedir, processed):
         expdir = os.path.join(nightdir, dirname)
         if expdir in processed:
             continue
-        if re.match('\d{8}', dirname) and os.path.isdir(expdir):
+        fits_fz_exists = np.any([re.match('desi-\d{8}.fits.fz', file) for file in os.listdir(expdir)])
+        if re.match('\d{8}', dirname) and os.path.isdir(expdir) and fits_fz_exists:
             break
     else:
         return None  #- no basename/YEARMMDD/EXPID directory was found


### PR DESCRIPTION
Will now check if a desi*.fits.fz file exists before trying to run qqa on the exposure file. 

Also, there was always a problem with qqa monitor where if there was another night directory after the current night directory, adding exposures to the current night directory would not work (ie if the data directory contained both 20190306 and 20190307, adding anything to 20190306 does not trigger qqa monitor). In this branch, this issue should be fixed. 

Addresses #75. 