### PR TITLE
Add startdate

### DIFF
--- a/py/qqa/run.py
+++ b/py/qqa/run.py
@@ -29,22 +29,16 @@ def get_ncpu(ncpu):
 
     return ncpu
 
-def limit_startdate(datadir, startdate):
-    all_nights = sorted(os.listdir(datadir))
-    #- only checks dates after startdate
-    if startdate:
-        #- TODO: add user error checks for startdate input format
-        startdate = str(startdate)
-        idx = np.searchsorted(all_nights, int(startdate))
-        all_nights = all_nights[idx:]
-    
-    return all_nights
 
-
-def find_unprocessed_expdir(datadir, outdir, startdate=None):
+def find_unprocessed_expdir(datadir, outdir, list_nights):
     '''
     Returns the earliest outdir/YEARMMDD/EXPID that has not yet been processed
     in outdir/YEARMMDD/EXPID.
+
+    Args:
+        datadir : a directory of nights with exposures
+        outdir : TODO DOCUMENTATION
+        list_nights : a list of nights to look at in DATADIR
 
     Returns directory, of None if no unprocessed directories were found
     (either because no inputs exist, or because all inputs have been processed)
@@ -52,9 +46,8 @@ def find_unprocessed_expdir(datadir, outdir, startdate=None):
     Warning: traverses the whole tree every time.
     TODO: cache previously identified already-processed data and don't rescan.
     '''
-    all_nights = limit_startdate(datadir, startdate)
     #- Search for the earliest unprocessed datadir/YYYYMMDD
-    for night in all_nights:
+    for night in list_nights:
         nightdir = os.path.join(datadir, night)
         if re.match('20\d{6}', night) and os.path.isdir(nightdir):
             for expid in sorted(os.listdir(nightdir)):
@@ -70,19 +63,19 @@ def find_unprocessed_expdir(datadir, outdir, startdate=None):
 
     return None
 
-def find_latest_expdir(basedir, processed, startdate=None):
+def find_latest_expdir(basedir, processed, list_nights):
     '''
     finds the earliest unprocessed basedir/YEARMMDD/EXPID from the latest
     YEARMMDD without traversing the whole tree
     Args:
-        basedir : 
+        basedir : a directory of nights with exposures
         processed : set of exposure directories already processed
+        list_nights : a list of nights to look at in BASEDIR
 
     Returns directory, or None if no matching directories are found
     '''
-    all_nights = limit_startdate(basedir, startdate)    
     #- Search for most recent basedir/YEARMMDD
-    for dirname in all_nights[::-1]: #sorted(os.listdir(basedir), reverse=True):
+    for dirname in list_nights[::-1]: #sorted(os.listdir(basedir), reverse=True):
         nightdir = os.path.join(basedir, dirname)
         if re.match('20\d{6}', dirname) and os.path.isdir(nightdir):
             night = dirname

--- a/py/qqa/run.py
+++ b/py/qqa/run.py
@@ -30,7 +30,7 @@ def get_ncpu(ncpu):
     return ncpu
 
 
-def find_unprocessed_expdir(datadir, outdir, list_nights):
+def find_unprocessed_expdir(datadir, outdir, startdate=None):
     '''
     Returns the earliest outdir/YEARMMDD/EXPID that has not yet been processed
     in outdir/YEARMMDD/EXPID.
@@ -38,7 +38,8 @@ def find_unprocessed_expdir(datadir, outdir, list_nights):
     Args:
         datadir : a directory of nights with exposures
         outdir : TODO DOCUMENTATION
-        list_nights : a list of nights to look at in DATADIR
+    Options:
+        startdate : the earliest night to consider processing YYYYMMDD
 
     Returns directory, of None if no unprocessed directories were found
     (either because no inputs exist, or because all inputs have been processed)
@@ -46,10 +47,15 @@ def find_unprocessed_expdir(datadir, outdir, list_nights):
     Warning: traverses the whole tree every time.
     TODO: cache previously identified already-processed data and don't rescan.
     '''
+    if startdate:
+        startdate = str(startdate)
+    else:
+        startdate = ''
+    all_nights = sorted(os.listdir(datadir))
     #- Search for the earliest unprocessed datadir/YYYYMMDD
     for night in list_nights:
         nightdir = os.path.join(datadir, night)
-        if re.match('20\d{6}', night) and os.path.isdir(nightdir):
+        if re.match('20\d{6}', night) and os.path.isdir(nightdir) and dirname >= startdate:
             for expid in sorted(os.listdir(nightdir)):
                 expdir = os.path.join(nightdir, expid)
                 if re.match('\d{8}', expid) and os.path.isdir(expdir):
@@ -63,21 +69,26 @@ def find_unprocessed_expdir(datadir, outdir, list_nights):
 
     return None
 
-def find_latest_expdir(basedir, processed, list_nights):
+def find_latest_expdir(basedir, processed, startdate=None):
     '''
     finds the earliest unprocessed basedir/YEARMMDD/EXPID from the latest
     YEARMMDD without traversing the whole tree
     Args:
         basedir : a directory of nights with exposures
         processed : set of exposure directories already processed
-        list_nights : a list of nights to look at in BASEDIR
+    Options:
+        startdate : the earliest night to consider processing YYYYMMDD
 
     Returns directory, or None if no matching directories are found
     '''
+    if startdate:
+        startdate = str(startdate)
+    else:
+        startdate = ''
     #- Search for most recent basedir/YEARMMDD
-    for dirname in list_nights[::-1]: #sorted(os.listdir(basedir), reverse=True):
+    for dirname in sorted(os.listdir(basedir), reverse=True):
         nightdir = os.path.join(basedir, dirname)
-        if re.match('20\d{6}', dirname) and os.path.isdir(nightdir):
+        if re.match('20\d{6}', dirname) and os.path.isdir(nightdir) and dirname >= startdate:
             night = dirname
             for dirname in sorted(os.listdir(nightdir)):
                 expid = dirname

--- a/py/qqa/run.py
+++ b/py/qqa/run.py
@@ -41,9 +41,15 @@ def find_unprocessed_expdir(datadir, outdir, startdate=None):
     TODO: cache previously identified already-processed data and don't rescan.
     '''
     all_nights = sorted(os.listdir(datadir))
-#     if startdate:
-#         all_nights = all_nights[:]
-    for night in sorted(os.listdir(datadir)):
+    #- only checks dates after startdate
+    if startdate:
+        #- TODO: add user error checks for startdate input format
+        startdate = int(startdate)
+        idx = np.searchsorted(all_nights, int(startdate))
+        all_nights = all_nights[idx:]
+    
+    #- Search for the earliest unprocessed datadir/YYYYMMDD
+    for night in all_nights:
         nightdir = os.path.join(datadir, night)
         if re.match('20\d{6}', night) and os.path.isdir(nightdir):
             for expid in sorted(os.listdir(nightdir)):
@@ -59,17 +65,26 @@ def find_unprocessed_expdir(datadir, outdir, startdate=None):
 
     return None
 
-def find_latest_expdir(basedir, processed):
+def find_latest_expdir(basedir, processed, startdate=None):
     '''
     finds the earliest unprocessed basedir/YEARMMDD/EXPID from the latest
     YEARMMDD without traversing the whole tree
-
-    processed: set of exposure directories already processed
+    Args:
+        basedir : 
+        processed : set of exposure directories already processed
 
     Returns directory, or None if no matching directories are found
     '''
+    all_nights = sorted(os.listdir(basedir))
+    #- only checks dates after startdate
+    if startdate:
+        #- TODO: add user error checks for startdate input format
+        startdate = int(startdate)
+        idx = np.searchsorted(all_nights, int(startdate))
+        all_nights = all_nights[idx:]
+    
     #- Search for most recent basedir/YEARMMDD
-    for dirname in sorted(os.listdir(basedir), reverse=True):
+    for dirname in all_nights[::-1]: #sorted(os.listdir(basedir), reverse=True):
         nightdir = os.path.join(basedir, dirname)
         if re.match('20\d{6}', dirname) and os.path.isdir(nightdir):
             night = dirname

--- a/py/qqa/run.py
+++ b/py/qqa/run.py
@@ -29,6 +29,18 @@ def get_ncpu(ncpu):
 
     return ncpu
 
+def limit_startdate(datadir, startdate):
+    all_nights = sorted(os.listdir(datadir))
+    #- only checks dates after startdate
+    if startdate:
+        #- TODO: add user error checks for startdate input format
+        startdate = str(startdate)
+        idx = np.searchsorted(all_nights, int(startdate))
+        all_nights = all_nights[idx:]
+    
+    return all_nights
+
+
 def find_unprocessed_expdir(datadir, outdir, startdate=None):
     '''
     Returns the earliest outdir/YEARMMDD/EXPID that has not yet been processed
@@ -40,14 +52,7 @@ def find_unprocessed_expdir(datadir, outdir, startdate=None):
     Warning: traverses the whole tree every time.
     TODO: cache previously identified already-processed data and don't rescan.
     '''
-    all_nights = sorted(os.listdir(datadir))
-    #- only checks dates after startdate
-    if startdate:
-        #- TODO: add user error checks for startdate input format
-        startdate = str(startdate)
-        idx = np.searchsorted(all_nights, int(startdate))
-        all_nights = all_nights[idx:]
-    
+    all_nights = limit_startdate(datadir, startdate)
     #- Search for the earliest unprocessed datadir/YYYYMMDD
     for night in all_nights:
         nightdir = os.path.join(datadir, night)
@@ -75,14 +80,7 @@ def find_latest_expdir(basedir, processed, startdate=None):
 
     Returns directory, or None if no matching directories are found
     '''
-    all_nights = sorted(os.listdir(basedir))
-    #- only checks dates after startdate
-    if startdate:
-        #- TODO: add user error checks for startdate input format
-        startdate = int(startdate)
-        idx = np.searchsorted(all_nights, int(startdate))
-        all_nights = all_nights[idx:]
-    
+    all_nights = limit_startdate(basedir, startdate)    
     #- Search for most recent basedir/YEARMMDD
     for dirname in all_nights[::-1]: #sorted(os.listdir(basedir), reverse=True):
         nightdir = os.path.join(basedir, dirname)

--- a/py/qqa/run.py
+++ b/py/qqa/run.py
@@ -44,7 +44,7 @@ def find_unprocessed_expdir(datadir, outdir, startdate=None):
     #- only checks dates after startdate
     if startdate:
         #- TODO: add user error checks for startdate input format
-        startdate = int(startdate)
+        startdate = str(startdate)
         idx = np.searchsorted(all_nights, int(startdate))
         all_nights = all_nights[idx:]
     

--- a/py/qqa/script.py
+++ b/py/qqa/script.py
@@ -89,29 +89,14 @@ def main_monitor(options=None):
     log.info('Monitoring {}/ for new raw data'.format(tmp))
 
     qarunner = QARunner()
-
     processed = set()
-
-    all_nights = sorted(os.listdir(args.indir))
     
-    #- only checks nights after startdate
-    if args.startdate:
-        #- TODO: add user error checks for startdate input format
-        #- finds the index of the earliest night to consider processing
-        startdate = str(args.startdate)
-        idx = np.searchsorted(all_nights, startdate)
-        #- counts number of skipped nights
-        skipped = len(all_nights[:idx])
-        #- subselects only nights after startdate
-        all_nights = all_nights[idx:]
-        print('Skipped {} night{} before {}'.format(skipped, 's' if skipped > 1 else '', 
-                                                         startdate))    
-    
+    #- TODO: figure out a way to print how many nights are being skipped before startdate
     while True:
         if args.catchup:
-            expdir = run.find_unprocessed_expdir(args.indir, args.outdir, all_nights)
+            expdir = run.find_unprocessed_expdir(args.indir, args.outdir, startdate=args.startdate)
         else:
-            expdir = run.find_latest_expdir(args.indir, processed, all_nights)
+            expdir = run.find_latest_expdir(args.indir, processed, startdate=args.startdate)
 
         if expdir is None:
             time.sleep(args.waittime)

--- a/py/qqa/script.py
+++ b/py/qqa/script.py
@@ -6,7 +6,6 @@ import os, sys, time, glob
 import argparse
 import traceback
 import subprocess
-import numpy as np
 from . import run, plots
 from .qa.runner import QARunner
 from desiutil.log import get_logger
@@ -63,13 +62,13 @@ def main_monitor(options=None):
     parser.add_argument("--cameras", type=str, help="comma separated list of cameras (for debugging)")
     parser.add_argument("--catchup", action="store_true", help="Catch up on processing all unprocessed data")
     parser.add_argument("--waittime", type=int, default=5, help="Seconds to wait between checks for new data")
-    parser.add_argument("--startdate", type=int, default=None, help="Earliest int startdate to check for unprocessed nights (YYYYMMDD)")
-    parser.add_argument("--batch", "-b", type=bool, default=False, help="True if you want qproc data processing to spawn a batch job")
-    parser.add_argument("--nodes", "-N", type=int, default=1, help="Number of nodes for qproc batch job \n batch must equal True")
-    parser.add_argument("--ntasks", "-n", type=int, default=1, help="Number of tasks per node for qproc batch job \n batch must equal True")
-    parser.add_argument("--constraint", "-C", type=str, default="haswell", help="Constraint for qproc batch job \n batch must equal True")
-    parser.add_argument("--qos", "-q", type=str, default="interactive", help="Qos for qproc batch job \n batch must equal True")
-    parser.add_argument("--time", "-t", type=int, default=5, help="time for qproc batch job \n batch must equal True")
+    parser.add_argument("--startdate", type=int, default=None, help="Earliest startdate to check for unprocessed nights (YYYYMMDD)")
+    parser.add_argument("--batch", "-b", type=bool, default=False, help="Bool, qproc data processing to batch job")
+    parser.add_argument("--nodes", "-N", type=int, default=1, help="Number of nodes for qproc batch job, batch=True")
+    parser.add_argument("--ntasks", "-n", type=int, default=1, help="Number of tasks per node for qproc batch job, batch=True")
+    parser.add_argument("--constraint", "-C", type=str, default="haswell", help="Constraint for qproc batch job, batch=True")
+    parser.add_argument("--qos", "-q", type=str, default="interactive", help="Qos for qproc batch job, batch=True")
+    parser.add_argument("--time", "-t", type=int, default=5, help="time for qproc batch job, batch=True")
 
     if options is None:
         options = sys.argv[2:]

--- a/py/qqa/script.py
+++ b/py/qqa/script.py
@@ -6,6 +6,7 @@ import os, sys, time, glob
 import argparse
 import traceback
 import subprocess
+import numpy as np
 from . import run, plots
 from .qa.runner import QARunner
 from desiutil.log import get_logger
@@ -90,11 +91,27 @@ def main_monitor(options=None):
     qarunner = QARunner()
 
     processed = set()
+
+    all_nights = sorted(os.listdir(args.indir))
+    
+    #- only checks nights after startdate
+    if args.startdate:
+        #- TODO: add user error checks for startdate input format
+        #- finds the index of the earliest night to consider processing
+        startdate = str(args.startdate)
+        idx = np.searchsorted(all_nights, startdate)
+        #- counts number of skipped nights
+        skipped = len(all_nights[:idx])
+        #- subselects only nights after startdate
+        all_nights = all_nights[idx:]
+        print('Skipped {} night{} before {}'.format(skipped, 's' if skipped > 1 else '', 
+                                                         startdate))    
+    
     while True:
         if args.catchup:
-            expdir = run.find_unprocessed_expdir(args.indir, args.outdir, startdate=args.startdate)
+            expdir = run.find_unprocessed_expdir(args.indir, args.outdir, all_nights)
         else:
-            expdir = run.find_latest_expdir(args.indir, processed)
+            expdir = run.find_latest_expdir(args.indir, processed, all_nights)
 
         if expdir is None:
             time.sleep(args.waittime)

--- a/py/qqa/script.py
+++ b/py/qqa/script.py
@@ -62,12 +62,13 @@ def main_monitor(options=None):
     parser.add_argument("--cameras", type=str, help="comma separated list of cameras (for debugging)")
     parser.add_argument("--catchup", action="store_true", help="Catch up on processing all unprocessed data")
     parser.add_argument("--waittime", type=int, default=5, help="Seconds to wait between checks for new data")
+    parser.add_argument("--startdate", type=int, default=None, help="Earliest int startdate to check for unprocessed nights (YYYYMMDD)")
     parser.add_argument("--batch", "-b", type=bool, default=False, help="True if you want qproc data processing to spawn a batch job")
-    parser.add_argument("--nodes", "-N", type=int, default=1, help="Number of nodes for qproc batch job")
-    parser.add_argument("--ntasks", "-n", type=int, default=1, help="Number of tasks per node for qproc batch job")
-    parser.add_argument("--constraint", "-C", type=str, default="haswell", help="Constraint for qproc batch job")
-    parser.add_argument("--qos", "-q", type=str, default="interactive", help="Qos for qproc batch job")
-    parser.add_argument("--time", "-t", type=int, default=5, help="time for qproc batch job")
+    parser.add_argument("--nodes", "-N", type=int, default=1, help="Number of nodes for qproc batch job \n batch must equal True")
+    parser.add_argument("--ntasks", "-n", type=int, default=1, help="Number of tasks per node for qproc batch job \n batch must equal True")
+    parser.add_argument("--constraint", "-C", type=str, default="haswell", help="Constraint for qproc batch job \n batch must equal True")
+    parser.add_argument("--qos", "-q", type=str, default="interactive", help="Qos for qproc batch job \n batch must equal True")
+    parser.add_argument("--time", "-t", type=int, default=5, help="time for qproc batch job \n batch must equal True")
 
     if options is None:
         options = sys.argv[2:]
@@ -91,7 +92,7 @@ def main_monitor(options=None):
     processed = set()
     while True:
         if args.catchup:
-            expdir = run.find_unprocessed_expdir(args.indir, args.outdir)
+            expdir = run.find_unprocessed_expdir(args.indir, args.outdir, startdate=args.startdate)
         else:
             expdir = run.find_latest_expdir(args.indir, processed)
 


### PR DESCRIPTION
Adds a startdate option to the args in qqa monitor
Addresses issue #86 

- adds if startdate blocks to both find_unprocessed_expdir and find_latest_expdir functions in run.py
- then uses np.searchsorted to determine the index of a sorted nights list where startdate would be placed
- limits the dates to consider processing with this index