### PR TITLE
spectro metadata col in exposures table

### DIFF
--- a/py/qqa/plots/core.py
+++ b/py/qqa/plots/core.py
@@ -143,3 +143,40 @@ def boxplot(q1, q2, q3, upper, lower, outliers, xpos, color='gray',
     fig.ygrid.grid_line_color = None
     fig.grid.grid_line_width = 2
     fig.xaxis.major_label_text_font_size="12pt"
+
+    
+    
+def parse_numlist(x):
+    '''
+    Generates a concise string output of the integers contained in x
+    by parsing the runs of consecutive elements
+    
+    Args:
+        x : a 1D list of numbers
+    '''
+    if not x:
+        return ''
+    #- gets sorted int array of distinct values in x
+    x = np.asarray(x).astype(int)
+    x = np.unique(x)
+    
+    #- TODO: is joining to a string faster or joining an array of strings
+    consecs = []
+    #- collects runs of consecutive elements in x
+    start = x[0]
+    r = str(start)
+    for i in range(1, len(x)+1):
+        print(consecs)
+        
+        if i < len(x) and x[i] == x[i-1]+1:
+            r = "{}-{}".format(start, x[i])
+            continue
+        
+        consecs.append(r)
+        
+        if i < len(x):
+            start = x[i]
+            r = str(start)
+
+    s = ','.join(consecs)
+    return s

--- a/py/qqa/plots/core.py
+++ b/py/qqa/plots/core.py
@@ -153,6 +153,13 @@ def parse_numlist(x):
     
     Args:
         x : a 1D list of numbers
+
+    e.g.
+        parse_numlist([1,2,3]) == '1-3'
+        parse_numlist([5,1,2,3]) == '1-3,5'
+        parse_numlist([5,1,2,3,6,7]) == '1-3,5-7'
+        parse_numlist([]) == ''
+        parse_numlist(None) == '???'
     '''
     if not x:
         return ''

--- a/py/qqa/plots/core.py
+++ b/py/qqa/plots/core.py
@@ -165,9 +165,7 @@ def parse_numlist(x):
     #- collects runs of consecutive elements in x
     start = x[0]
     r = str(start)
-    for i in range(1, len(x)+1):
-        print(consecs)
-        
+    for i in range(1, len(x)+1):        
         if i < len(x) and x[i] == x[i-1]+1:
             r = "{}-{}".format(start, x[i])
             continue

--- a/py/qqa/webpages/tables.py
+++ b/py/qqa/webpages/tables.py
@@ -16,8 +16,7 @@ def write_nights_table(outfile, exposures):
     """
     outfile: output HTML file
     exposures: table with columns NIGHT, EXPID
-    """
-
+    """    
     env = jinja2.Environment(
         loader=jinja2.PackageLoader('qqa.webpages', 'templates')
     )
@@ -162,16 +161,22 @@ def write_exposures_tables(indir,outdir, exposures, nights=None):
         ii = (exposures['NIGHT'] == night)
         explist = list()
         for expid in sorted(exposures['EXPID'][ii]):
-
             qafile = io.findfile('qa', night, expid, basedir=indir)
             qadata = io.read_qa(qafile)
             status = get_status(qadata)
             flavor = qadata['HEADER']['FLAVOR'].rstrip()
             exptime = qadata['HEADER']['EXPTIME']
+            
+            from ..plots.core import parse_numlist
+            str_specs = qadata['HEADER'].get('SPECGRPH', '').strip(" ")
+            list_specs = re.findall('\d+', str_specs)
+            spectros = parse_numlist(list_specs)
+            
             link = '{expid:08d}/qa-summary-{expid:08d}.html'.format(
                 night=night, expid=expid)
 
-            expinfo = dict(night=night, expid=expid, flavor=flavor, link=link, exptime=exptime)
+            expinfo = dict(night=night, expid=expid, flavor=flavor, link=link, 
+                           exptime=exptime, spectros=spectros)
 
             #- TODO: have actual thresholds
             for i, qatype in enumerate(['PER_AMP', 'PER_CAMERA', 'PER_FIBER',

--- a/py/qqa/webpages/tables.py
+++ b/py/qqa/webpages/tables.py
@@ -168,9 +168,12 @@ def write_exposures_tables(indir,outdir, exposures, nights=None):
             exptime = qadata['HEADER']['EXPTIME']
             
             from ..plots.core import parse_numlist
-            str_specs = qadata['HEADER'].get('SPECGRPH', '').strip(" ")
-            list_specs = re.findall('\d+', str_specs)
-            spectros = parse_numlist(list_specs)
+            peramp = status.get('PER_AMP')
+            if peramp:
+                list_specs = list(set(peramp['SPECTRO']))
+                spectros = parse_numlist(list_specs)
+            else:
+                spectros = '???'
             
             link = '{expid:08d}/qa-summary-{expid:08d}.html'.format(
                 night=night, expid=expid)

--- a/py/qqa/webpages/templates/exposures.html
+++ b/py/qqa/webpages/templates/exposures.html
@@ -37,13 +37,14 @@
 
 <table>
 <tr>
-  <th colspan="4">Metadata</th>
+  <th colspan="5">Metadata</th>
   <th colspan="6">QA Status</th>
 <tr>
   <th>NIGHT</th>
   <th>EXPID</th>
   <th>FLAVOR</th>
   <th>EXPTIME</th>
+  <th>SPECTROS</th>
   <th>Amp</th>
   <th>Camera</th>
   <th>Fiber</th>
@@ -58,6 +59,7 @@
   <td><a href="{{ exp.link }}">{{ exp.expid }}</a></td>
   <td>{{ exp.flavor }}</td>
   <td>{{ exp.exptime }}</td>
+  <td>{{ exp.spectros }}</td>
 
 {% if exp.PER_AMP_link != "na" %}
   <td><a href="{{ exp.PER_AMP_link }}">{{ exp.PER_AMP }}</a></td>


### PR DESCRIPTION
Adds a column to the exposures table on the metadata side listing the spectros

![image](https://user-images.githubusercontent.com/46800082/60295093-c3178580-98d7-11e9-9f49-055e5de4e222.png)

- function in plots.core for parsing a list of numbers to a string so output looks like 0-4,8
- robust against missing spectrographs (see synthetic data? unless I just could not identify the column name)
- TODO: I could only check it on exposures with either a single spectro or none at all, not sure what the format is for parsing multiple spectrographs from the qadata file, and if that will error
Addresses #85 