### PR TITLE
Robustness

### DIFF
--- a/py/qqa/plots/camera.py
+++ b/py/qqa/plots/camera.py
@@ -33,6 +33,12 @@ def plot_camera_qa(table, attribute, height=225, width=450, title=None, line0 = 
     for cam in ["B", "R", "Z"]:
         
         cam_table = astrotable[astrotable["CAM"]==cam]
+
+        if len(cam_table) == 0:
+            #- Create placeholder fig if not data for this camera
+            fig = bk.figure(plot_height=height, plot_width=width, title='No {} data'.format(cam))
+            continue
+
         fig = bk.figure(plot_height=height, plot_width=width, title = title+" "+cam)
         source = ColumnDataSource(data=dict(
             SPECTRO = cam_table["SPECTRO"],
@@ -54,7 +60,11 @@ def plot_camera_qa(table, attribute, height=225, width=450, title=None, line0 = 
         fig.yaxis.axis_label = attribute
         if minmax is not None:
             ymin, ymax = minmax
-            attrmin = np.min(cam_table["MIN"+attribute])
+            try:
+                attrmin = np.min(cam_table["MIN"+attribute])
+            except:
+                import IPython; IPython.embed()
+
             attrmax = np.max(cam_table["MAX"+attribute])
 
             #- Data ranges are within minmax

--- a/py/qqa/plots/camera.py
+++ b/py/qqa/plots/camera.py
@@ -60,11 +60,7 @@ def plot_camera_qa(table, attribute, height=225, width=450, title=None, line0 = 
         fig.yaxis.axis_label = attribute
         if minmax is not None:
             ymin, ymax = minmax
-            try:
-                attrmin = np.min(cam_table["MIN"+attribute])
-            except:
-                import IPython; IPython.embed()
-
+            attrmin = np.min(cam_table["MIN"+attribute])
             attrmax = np.max(cam_table["MAX"+attribute])
 
             #- Data ranges are within minmax

--- a/py/qqa/plots/camfiber.py
+++ b/py/qqa/plots/camfiber.py
@@ -144,7 +144,15 @@ def plot_per_fibernum(cds, attribute, cameras, titles={},
         
         #- focused y-ranges unless outliers in data
         cam_metric = metric[np.array(cds.data.get('CAM')) == c]
+
+        if len(cam_metric) == 0:
+            #- create a blank plot as a placeholder
+            fig = bokeh.plotting.figure(plot_width=width, plot_height=height)
+            figs_list.append(fig)
+            continue
+
         plotmin = min(ymin, np.min(cam_metric) * 0.9) if ymin else np.min(cam_metric) * 0.9
+
         plotmax = max(ymax, nnp.max(cam_metric) * 1.1) if ymax else np.max(cam_metric) * 1.1
 
         fig_y_range = bokeh.models.Range1d(plotmin, plotmax)

--- a/py/qqa/plots/camfiber.py
+++ b/py/qqa/plots/camfiber.py
@@ -152,7 +152,6 @@ def plot_per_fibernum(cds, attribute, cameras, titles={},
             continue
 
         plotmin = min(ymin, np.min(cam_metric) * 0.9) if ymin else np.min(cam_metric) * 0.9
-
         plotmax = max(ymax, nnp.max(cam_metric) * 1.1) if ymax else np.max(cam_metric) * 1.1
 
         fig_y_range = bokeh.models.Range1d(plotmin, plotmax)

--- a/py/qqa/qa/runner.py
+++ b/py/qqa/qa/runner.py
@@ -42,7 +42,7 @@ class QARunner(object):
         preprocfiles = sorted(glob.glob('{}/preproc-*.fits'.format(indir)))
         if len(preprocfiles) == 0:
             log.error('No preproc files found in {}'.format(indir))
-            raise RuntimeError
+            return None
 
         # We can have different flavors (signal+dark) with calibration data
         # obtained with a calibration slit hooked to a single spectrograph.

--- a/py/qqa/qa/traceshift.py
+++ b/py/qqa/qa/traceshift.py
@@ -25,6 +25,10 @@ class QATraceShift(QA):
         '''TODO: document'''
         log = desiutil.log.get_logger()
         infiles = glob.glob(os.path.join(indir, 'psf-*.fits'))
+        if len(infiles) == 0:
+            log.error('No {}/psf*.fits files found'.format(indir))
+            return None
+
         results = list()
         for filename in infiles:
             log.debug(filename)

--- a/py/qqa/run.py
+++ b/py/qqa/run.py
@@ -53,9 +53,10 @@ def find_unprocessed_expdir(datadir, outdir, startdate=None):
         startdate = ''
     all_nights = sorted(os.listdir(datadir))
     #- Search for the earliest unprocessed datadir/YYYYMMDD
-    for night in list_nights:
+    for night in all_nights:
         nightdir = os.path.join(datadir, night)
-        if re.match('20\d{6}', night) and os.path.isdir(nightdir) and dirname >= startdate:
+        if re.match('20\d{6}', night) and os.path.isdir(nightdir) and \
+                night >= startdate:
             for expid in sorted(os.listdir(nightdir)):
                 expdir = os.path.join(nightdir, expid)
                 if re.match('\d{8}', expid) and os.path.isdir(expdir):

--- a/py/qqa/run.py
+++ b/py/qqa/run.py
@@ -89,8 +89,8 @@ def find_latest_expdir(basedir, processed, startdate=None):
     else:
         startdate = ''
 
+    log = desiutil.log.get_logger()
     #- Search for most recent basedir/YEARMMDD
-    nightdir = None
     for dirname in sorted(os.listdir(basedir), reverse=True):
         nightdir = os.path.join(basedir, dirname)
         if re.match('20\d{6}', dirname) and dirname >= startdate and \
@@ -98,6 +98,7 @@ def find_latest_expdir(basedir, processed, startdate=None):
             break
     #- if for loop completes without finding nightdir to break, run this else
     else:
+        log.debug('No YEARMMDD dirs found in {}'.format(basedir))
         return None
 
     night = dirname
@@ -109,11 +110,13 @@ def find_latest_expdir(basedir, processed, startdate=None):
         expid = dirname
         datafilename = os.path.join(expdir, 'desi-{}.fits.fz'.format(expid))
         if os.path.isfile(datafilename):
+            log.debug('Found {}'.format(datafilename))
             return expdir
         else:
-            print('Skipping {}/{} with no desi*.fits.fz'.format(night, expid))
+            log.debug('Skipping {}/{} with no desi*.fits.fz'.format(night, expid))
             processed.add(expdir)  #- so that we won't check again
     else:
+        log.debug('No new exposures found')
         return None  #- no basename/YEARMMDD directory was found
 
 def which_cameras(rawfile):

--- a/py/qqa/run.py
+++ b/py/qqa/run.py
@@ -80,28 +80,39 @@ def find_latest_expdir(basedir, processed, startdate=None):
         startdate : the earliest night to consider processing YYYYMMDD
 
     Returns directory, or None if no matching directories are found
+
+    Note: if you want the first unprocessed directory, use
+    `find_unprocessed_expdir` instead
     '''
     if startdate:
         startdate = str(startdate)
     else:
         startdate = ''
+
     #- Search for most recent basedir/YEARMMDD
+    nightdir = None
     for dirname in sorted(os.listdir(basedir), reverse=True):
         nightdir = os.path.join(basedir, dirname)
-        if re.match('20\d{6}', dirname) and os.path.isdir(nightdir) and dirname >= startdate:
-            night = dirname
-            for dirname in sorted(os.listdir(nightdir)):
-                expid = dirname
-                expdir = os.path.join(nightdir, dirname)
-                if expdir in processed:
-                    continue
-                fits_fz_exists = np.any([re.match('desi-\d{8}.fits.fz', file) for file in os.listdir(expdir)])
-                if re.match('\d{8}', dirname) and os.path.isdir(expdir) and fits_fz_exists:
-                    return expdir
-                else:
-                    print('Skipping {}/{} with no desi*.fits.fz data'.format(night, expid))
-            #else:
-            #    return None  #- no basename/YEARMMDD/EXPID directory was found
+        if re.match('20\d{6}', dirname) and dirname >= startdate and \
+                os.path.isdir(nightdir):
+            break
+    #- if for loop completes without finding nightdir to break, run this else
+    else:
+        return None
+
+    night = dirname
+    for dirname in sorted(os.listdir(nightdir)):
+        expdir = os.path.join(nightdir, dirname)
+        if expdir in processed:
+            continue
+
+        expid = dirname
+        datafilename = os.path.join(expdir, 'desi-{}.fits.fz'.format(expid))
+        if os.path.isfile(datafilename):
+            return expdir
+        else:
+            print('Skipping {}/{} with no desi*.fits.fz'.format(night, expid))
+            processed.add(expdir)  #- so that we won't check again
     else:
         return None  #- no basename/YEARMMDD directory was found
 

--- a/py/qqa/script.py
+++ b/py/qqa/script.py
@@ -189,6 +189,7 @@ def main_monitor(options=None):
 
             processed.add(expdir)
 
+        sys.stdout.flush()
         time.sleep(args.waittime)
 
 def main_run(options=None):

--- a/py/qqa/script.py
+++ b/py/qqa/script.py
@@ -167,9 +167,9 @@ def main_monitor(options=None):
                 qarunner.run(indir=outdir, outfile=qafile, jsonfile=jsonfile)
 
                 print('Generating plots for {}/{}'.format(night, expid))
-                expdir = '{}/{}/{}'.format(args.plotdir, night, expid)
-                if not os.path.isdir(expdir) :
-                    os.makedirs(expdir)
+                tmpdir = '{}/{}/{}'.format(args.plotdir, night, expid)
+                if not os.path.isdir(tmpdir) :
+                    os.makedirs(tmpdir)
                 run.make_plots(infile=qafile, basedir=args.plotdir, preprocdir=outdir, cameras=cameras)
 
                 run.write_tables(args.outdir, args.plotdir)

--- a/py/qqa/script.py
+++ b/py/qqa/script.py
@@ -105,7 +105,7 @@ def main_monitor(options=None):
         rawfile = os.path.join(expdir, 'desi-{}.fits.fz'.format(expid))
         if expdir not in processed and os.path.exists(rawfile):
             outdir = '{}/{}/{}'.format(args.outdir, night, expid)
-            if os.path.exists(outdir) and len(glob.glob(outdir+'/*.fits'))>0:
+            if os.path.exists(outdir) and len(glob.glob(outdir+'/qa-*.fits'))>0:
                 print('Skipping previously processed {}/{}'.format(night, expid))
                 processed.add(expdir)
                 continue

--- a/py/qqa/webpages/summary.py
+++ b/py/qqa/webpages/summary.py
@@ -48,15 +48,16 @@ def get_summary_plots(qadata, qprocdir=None):
     plot_height = 110
 
     #- CCD Read Noise
-    fig = plot_amp_qa(qadata['PER_AMP'], 'READNOISE', title='CCD Amplifier Read Noise',
-        qamin=1.5, qamax=4.0, ymin=0, ymax=5.0,
-        plot_width=plot_width, plot_height=plot_height)
-    script, div = components(fig)
-    html_components['READNOISE'] = dict(script=script, div=div)
-
+    if 'PER_AMP' in qadata:
+        fig = plot_amp_qa(qadata['PER_AMP'], 'READNOISE',
+                title='CCD Amplifier Read Noise',
+                qamin=1.5, qamax=4.0, ymin=0, ymax=5.0,
+                plot_width=plot_width, plot_height=plot_height)
+        script, div = components(fig)
+        html_components['READNOISE'] = dict(script=script, div=div)
     
     #- Raw flux
-    if flavor.upper() in ['ARC', 'FLAT']:
+    if flavor.upper() in ['ARC', 'FLAT'] and 'PER_CAMFIBER' in qadata:
         cameras = np.unique(qadata['PER_CAMFIBER']['CAM'].astype(str))
         cds = camfiber.get_cds(qadata['PER_CAMFIBER'], ['INTEG_RAW_FLUX',], cameras)
         figs_list = camfiber.plot_per_fibernum(cds, 'INTEG_RAW_FLUX', cameras,
@@ -68,7 +69,7 @@ def get_summary_plots(qadata, qprocdir=None):
         html_components['RAWFLUX'] = dict(script=script, div=div)
 
     #- Calib flux
-    if flavor.upper() in ['SCIENCE']:
+    if flavor.upper() in ['SCIENCE'] and 'PER_CAMFIBER' in qadata:
         cameras = np.unique(qadata['PER_CAMFIBER']['CAM'].astype(str))
         cds = camfiber.get_cds(qadata['PER_CAMFIBER'], ['INTEG_CALIB_FLUX',], cameras)
         figs_list = camfiber.plot_per_fibernum(cds, 'INTEG_CALIB_FLUX', cameras,

--- a/py/qqa/webpages/summary.py
+++ b/py/qqa/webpages/summary.py
@@ -73,11 +73,12 @@ def get_summary_plots(qadata, qprocdir=None):
         cds = camfiber.get_cds(qadata['PER_CAMFIBER'], ['INTEG_CALIB_FLUX',], cameras)
         figs_list = camfiber.plot_per_fibernum(cds, 'INTEG_CALIB_FLUX', cameras,
             height=plot_height, ymin=0, width=plot_width)
-        figs_list[0].title = bokeh.models.Title(text="Integrated Sky-sub Calib Flux Per Fiber")
-        fn_camfiber_layout = layout(figs_list)
 
-        script, div = components(fn_camfiber_layout)
-        html_components['CALIBFLUX'] = dict(script=script, div=div)
+        if figs_list is not None:
+            figs_list[0].title = bokeh.models.Title(text="Integrated Sky-sub Calib Flux Per Fiber")
+            fn_camfiber_layout = layout(figs_list)
+            script, div = components(fn_camfiber_layout)
+            html_components['CALIBFLUX'] = dict(script=script, div=div)
 
     #- Random Spectra
     if flavor.upper() in ['ARC', 'FLAT', 'SCIENCE'] and \


### PR DESCRIPTION
This PR contains hotfixes implemented at KPNO to accommodate data problems encountered during 20190618 - 20190627.  Most of the changes are making sure that things don't crash if there is a missing HDU or keyword or a len=0 table.  Normally I'm a fan of "crash early, crash often" but in this case, we want to be super robust and just keep going so that a problem with one exposure doesn't take down all future exposures.

One substantive change was to revert the logic in `find_latest_expdir` to only search for the latest unprocessed exposure in the most recent night.  Otherwise it scans the entire directory tree every 10 second iteration.  When the intension is to really catch up on old exposures, use `find_unprocessed_expdir`, which is what `qqa monitor ... --catchup` uses.

I'd like to merge these changes soon so that they don't build up any more conflicts with master, but I'd appreciate an extra check processing at NERSC and/or laptops too.

@rdoshi99 @ana-lyons @williyamshoe could one of you try this branch?