### PR TITLE
Generating summary fits file and using it in timeseries

### DIFF
--- a/py/qqa/plots/amp.py
+++ b/py/qqa/plots/amp.py
@@ -122,9 +122,12 @@ def plot_amp_cam_qa(data, name, cam, labels, qamin, qamax,
     fig.circle(x='locations', y='data_val', line_color=None,
                  fill_color='colors', size='sizes', source=source, name='circles')
 
-
-    plotmin = min(ymin, np.min(data_val) * 0.9) if ymin else np.min(data_val) * 0.9
-    plotmax = max(ymax, np.max(data_val) * 1.1) if ymax else np.max(data_val) * 1.1
+    if len(data_val)>0 :
+        plotmin = min(ymin, np.min(data_val) * 0.9) if ymin else np.min(data_val) * 0.9
+        plotmax = max(ymax, np.max(data_val) * 1.1) if ymax else np.max(data_val) * 1.1
+    else :
+        plotmin = ymin
+        plotmax = ymax
     fig.y_range = Range1d(plotmin, plotmax)
     
     #- style visual attributes

--- a/py/qqa/plots/timeseries.py
+++ b/py/qqa/plots/timeseries.py
@@ -23,7 +23,18 @@ def generate_timeseries(data_dir, start_date, end_date, hdu, aspect):
         if (start_date <= dir and end_date >= dir):
             avaliable_dates += [os.path.join(i, dir)]
 
-    for date in avaliable_dates:
+    for date in avaliable_dates:   
+        nights_qa = os.path.join(date, "qa-n{}.fits".format(os.path.basename(date)))     
+        if os.path.isfile(nights_qa):
+            try:
+                print("found {}".format(os.path.join(date, "qa-n{}.fits".format(os.path.basename(date)))))
+                #list_tables += [Table.read(os.path.join(i, file), hdu=hdu)]
+                list_tables += [fitsio.read(nights_qa, hdu, columns=list(QA.metacols[hdu])+[aspect])]
+            except Exception as e:
+                print("{} does not have desired hdu or column".format(file))
+            continue
+
+        print("cannot find {}".format("qa-n{}.fits".format(os.path.basename(date))))
         for i,j,y in os.walk(date):
             for file in y:
                 if re.match(r"qa-[0-9]{8}.fits", file):
@@ -145,7 +156,7 @@ def generate_timeseries(data_dir, start_date, end_date, hdu, aspect):
             else:
                 fig.x_range=first.x_range
 
-        fig = gridplot([[i] for i in cam_figs], sizing_mode="fixed")
+        fig = gridplot([[i] for i in cam_figs])
 
     else:
         fig = bk.figure(toolbar_location="above", plot_height = 300, plot_width = 800)

--- a/py/qqa/run.py
+++ b/py/qqa/run.py
@@ -10,6 +10,7 @@ from astropy.table import Table, vstack
 import desiutil.log
 
 import desispec.scripts.preproc
+from qqa.qa.base import QA
 
 def get_ncpu(ncpu):
     """

--- a/py/qqa/run.py
+++ b/py/qqa/run.py
@@ -366,7 +366,7 @@ def make_plots(infile, basedir, preprocdir=None, logdir=None, cameras=None):
     htmlfile = '{}/qa-summary-{:08d}.html'.format(expdir, expid)
     web_summary.write_summary_html(htmlfile, qadata, preprocdir)
     print('Wrote {}'.format(htmlfile))
-    
+
     #- Note: last exposure goes in basedir, not expdir=basedir/NIGHT/EXPID
     htmlfile = '{}/qa-lastexp.html'.format(basedir)
     web_lastexp.write_lastexp_html(htmlfile, qadata, preprocdir)
@@ -490,6 +490,7 @@ def write_nights_summary(indir, last):
                 else:
                     qadata = Table(fitsio.read(fitsfile, "PER_AMP"))
                     if (qadata_stacked is None):
+                        hdr = fitsio.read_header(fitsfile, 0)
                         qadata_stacked = qadata
                     else:
                         qadata_stacked = vstack([qadata_stacked, qadata], metadata_conflicts='silent')
@@ -497,6 +498,12 @@ def write_nights_summary(indir, last):
             if qadata_stacked is None:
                 print("no exposures found")
                 return
+
+            night_qafile = '{indir}/{night}/qa-n{night}.fits'.format(indir=indir, night=night)
+            if not os.path.isfile(night_qafile):
+                with fitsio.FITS(night_qafile, 'rw', clobber=True) as fx:
+                    fx.write(np.zeros(3, dtype=float), extname='PRIMARY', header=hdr)
+                    fx.write_table(qadata_stacked.as_array(), extname="PER_AMP", header=hdr)
 
             readnoise_sca = dict()
             bias_sca = dict()

--- a/py/qqa/run.py
+++ b/py/qqa/run.py
@@ -480,8 +480,8 @@ def write_nights_summary(indir, last):
 
     for night in nights:
         jsonfile = os.path.join(indir, night, "summary.json")
-        if not os.path.isfile(jsonfile):
-            night_qafile = '{indir}/{night}/qa-n{night}.fits'.format(indir=indir, night=night)
+        night_qafile = '{indir}/{night}/qa-n{night}.fits'.format(indir=indir, night=night)
+        if (not os.path.isfile(jsonfile)) or (not os.path.isfile(night_qafile)):
             expids = next(os.walk(os.path.join(indir, night)))[1]
             expids = [expid for expid in expids if re.match(r"[0-9]{8}", expid)]
             qadata_stacked = dict()
@@ -495,13 +495,13 @@ def write_nights_summary(indir, last):
                             qadata = Table(fitsio.read(fitsfile, attr))
                         except:
                             continue
-                        
+
                         if (attr not in qadata_stacked):
                             hdr = fitsio.read_header(fitsfile, 0)
                             qadata_stacked[attr] = qadata
                         else:
                             qadata_stacked[attr] = vstack([qadata_stacked[attr], qadata], metadata_conflicts='silent')
-                            
+
                         print("processed {}".format(fitsfile))
 
             if len(qadata_stacked) == 0:


### PR DESCRIPTION
Within qqa summary, in addition to generating the `summary.json`, it will also generate a `qa-n{night}.fits` file, which is structured like `qa-{expid}.fits`, but vertically stacked over all exposures within that night. 

Also, now when calling timeseries, rather than calling each `qa-{expid}.fits`, it will just read `qa-n{night}.fits` if it exists. The `qa-n{night}.fits` files also seems useful when plotting thresholds, or other applications that will aggregate exposure data over many nights.

Followup to issue #37.