### PR TITLE
Qproc fail tracking

### DIFF
--- a/py/qqa/run.py
+++ b/py/qqa/run.py
@@ -315,8 +315,6 @@ def make_plots(infile, basedir, preprocdir=None, logdir=None, cameras=None):
         cameras: list of cameras (strings) to generate image files of. If not
             provided, will generate a cameras list from parcing through the
             preproc fits files in the preprocdir
-        qproc_fails: list of failed qproc processes for this night/expid
-
     '''
 
     from qqa.webpages import amp as web_amp
@@ -422,11 +420,11 @@ def make_plots(infile, basedir, preprocdir=None, logdir=None, cameras=None):
         #- plot logfile nav table
         htmlfile = '{}/qa-summary-{:08d}-logfiles_table.html'.format(expdir, expid)
         web_summary.write_logtable_html(htmlfile, logdir, night, expid, available=log_cams, 
-                                        error_colors=error_colors, qproc_fails=qproc_fails)
+                                        error_colors=error_colors)
 
 
 def write_tables(indir, outdir):
-    '''TODO: document
+    '''
     Parses directory for available nights, exposures to generate
     nights and exposures tables
     

--- a/py/qqa/run.py
+++ b/py/qqa/run.py
@@ -276,7 +276,7 @@ def run_qproc(rawfile, outdir, ncpu=None, cameras=None):
         pool.close()
         pool.join()
     else:
-        log.info('Running qproc serially for {} cameras'.format(ncpu))
+        log.info('Running qproc serially for {} cameras'.format(len(cameras)))
         for cmd, logfile, msg in zip(cmdlist, loglist, msglist):
             runcmd(cmd, logfile, msg)
 

--- a/py/qqa/run.py
+++ b/py/qqa/run.py
@@ -457,7 +457,7 @@ def write_tables(indir, outdir):
                     preproc_cams = [i.split("-")[1] for i in os.listdir(expdir) 
                                     if re.match(r'preproc-.*-.*.fits', i)]
                     log_cams = [i.split("-")[1] for i in os.listdir(expdir) if re.match(r'.*\.log', i)]
-                    qfails = len([i for i in log_cams if i not in preproc_cams])
+                    qfails = [i for i in log_cams if i not in preproc_cams]
                     
                     if os.path.exists(qafile):
                         rows.append(dict(NIGHT=night, EXPID=expid, FAIL=0, QPROC=qfails))

--- a/py/qqa/run.py
+++ b/py/qqa/run.py
@@ -462,7 +462,7 @@ def write_tables(indir, outdir):
                     qfails = len([i for i in log_cams if i not in preproc_cams])
                     
                     if os.path.exists(qafile):
-                        rows.append(dict(NIGHT=night, EXPID=expid, fAIL=0, QPROC=qfails))
+                        rows.append(dict(NIGHT=night, EXPID=expid, FAIL=0, QPROC=qfails))
                     else:
                         log.error('Missing {}'.format(qafile))
                         rows.append(dict(NIGHT=night, EXPID=expid, FAIL=1, QPROC=None))

--- a/py/qqa/script.py
+++ b/py/qqa/script.py
@@ -140,7 +140,7 @@ def main_monitor(options=None):
                     batchcmd = 'srun -N {nodes} -n {ntasks} -C {constraint} -q {qos} -t {time} '
                     runfile = 'python {dirfile} wrap_qproc --rawfile {rawfile} --outdir {outdir}'
                     if cameras:
-                        runfile += '--cameras {cameras}'
+                        runfile += ' --cameras {cameras}'
 
                     cmd = (batchcmd + runfile).format(**batch_dict)
                     err = subprocess.call(cmd.split())

--- a/py/qqa/script.py
+++ b/py/qqa/script.py
@@ -156,12 +156,7 @@ def main_monitor(options=None):
 
                 if not run_batch_qproc:
                     print('Running qproc on {}'.format(rawfile))
-                    #- TODO: delete
-                    print('qproc_fails is ')
-                    print(qproc_fails)
                     header = run.run_qproc(rawfile, outdir, cameras=cameras, qproc_fails=qproc_fails)
-                    print('qproc fails is ')
-                    print(qproc_fails)
 
                 print('Running QA on {}/{}'.format(night, expid))
                 qafile = "{}/qa-{}.fits".format(outdir,expid)
@@ -180,7 +175,7 @@ def main_monitor(options=None):
                 run.make_plots(infile=qafile, basedir=args.plotdir, preprocdir=outdir, logdir=outdir,
                                cameras=cameras, qproc_fails=qproc_fails)
 
-                run.write_tables(args.outdir, args.plotdir, qfails=qproc_fails)
+                run.write_tables(args.outdir, args.plotdir, qproc_fails=qproc_fails)
 
                 time_end = time.time()
                 dt = (time_end - time_start) / 60

--- a/py/qqa/webpages/summary.py
+++ b/py/qqa/webpages/summary.py
@@ -206,7 +206,7 @@ def write_logfile_html(input, output, night):
     expid = os.path.basename(input).split("-")[2].split(".")[0]
     
     error_level = 0
-    error_colors = dict({0:'green', 1:'orange', 2:'pink', 3:'red'})
+    error_colors = dict({0:'green', 1:'orange', 2:'red', 3:'red'})
 
     lines = []
     f = open(input, "rb")
@@ -220,7 +220,7 @@ def write_logfile_html(input, output, night):
             line = '<span style="color:{};">'.format(error_colors.get(2)) + line + '</span>'
             error_level = max(error_level, 2)
         elif 'CRITICAL' in line or 'FATAL' in line or 'Traceback' in line:
-            line = '<span style="color:{};">'.format(error_colors.get(3)) + line + '</span>'
+            line = '<span style="color:{};"><mark>'.format(error_colors.get(3)) + line + '</mark></span>'
             error_level = max(error_level, 3)
 
         lines.append(line)

--- a/py/qqa/webpages/summary.py
+++ b/py/qqa/webpages/summary.py
@@ -129,7 +129,7 @@ def write_summary_html(outfile, qadata, qprocdir):
 
 
 
-def write_logtable_html(outfile, logdir, night, expid, error_colors=dict()):
+def write_logtable_html(outfile, logdir, night, expid, error_colors=dict(), qproc_fails=[]):
     """Write a table of logfiles to outfile
 
     Args:
@@ -137,7 +137,9 @@ def write_logtable_html(outfile, logdir, night, expid, error_colors=dict()):
         logdir : directory containing log outputs
         night : YYYYMMDD night of logdir
         expid : exposure ID of logdir
+    Options:
         error_colors : dictionary of error colors corresponding to each camera
+        qproc_fails : a list of failed qproc processes
 
     Returns:
         None
@@ -155,6 +157,11 @@ def write_logtable_html(outfile, logdir, night, expid, error_colors=dict()):
     logfiles = [i for i in os.listdir(logdir) if re.match(r'.*\.log', i)]
     for file in logfiles:
         available += [file.split("-")[1]]
+
+    #- TODO: delete
+    print('debugging in summary.py, line 162')
+    import IPython
+    IPython.embed()
     
     html_components = dict(
         version=bokeh.__version__, logfile=True, night=night, available=available,

--- a/py/qqa/webpages/summary.py
+++ b/py/qqa/webpages/summary.py
@@ -55,7 +55,7 @@ def get_summary_plots(qadata, qprocdir=None):
                 plot_width=plot_width, plot_height=plot_height)
         script, div = components(fig)
         html_components['READNOISE'] = dict(script=script, div=div)
-    
+
     #- Raw flux
     if flavor.upper() in ['ARC', 'FLAT'] and 'PER_CAMFIBER' in qadata:
         cameras = np.unique(qadata['PER_CAMFIBER']['CAM'].astype(str))
@@ -129,7 +129,7 @@ def write_summary_html(outfile, qadata, qprocdir):
 
 
 
-def write_logtable_html(outfile, logdir, night, expid, available=None, error_colors=dict(), 
+def write_logtable_html(outfile, logdir, night, expid, available=None, error_colors=dict(),
                         qproc_fails=[]):
     """Write a table of logfiles to outfile
 
@@ -149,13 +149,13 @@ def write_logtable_html(outfile, logdir, night, expid, available=None, error_col
         loader=jinja2.PackageLoader('qqa.webpages', 'templates')
     )
     template = env.get_template('logfile.html')
-    
+
     if not logdir:
         logdir = ''
-    
+
     if available==None:
         available = []
-    
+
         logfiles = [i for i in os.listdir(logdir) if re.match(r'.*\.log', i)]
         for file in logfiles:
             available += [file.split("-")[1]]
@@ -163,7 +163,7 @@ def write_logtable_html(outfile, logdir, night, expid, available=None, error_col
     #- Shows all failed qprocs as red
     for qfail in qproc_fails:
         error_colors[qfail] = 'red'
-    
+
     html_components = dict(
         version=bokeh.__version__, logfile=True, night=night, available=available,
         current=None, expid=int(expid), zexpid='{:08d}'.format(expid),
@@ -178,7 +178,7 @@ def write_logtable_html(outfile, logdir, night, expid, available=None, error_col
     print('Wrote {}'.format(outfile))
 
 
-    
+
 def write_logfile_html(input, output, night):
     """Write a qproc logfile to an HTML webpage
 
@@ -204,9 +204,9 @@ def write_logfile_html(input, output, night):
 
     current = os.path.basename(input).split("-")[1]
     expid = os.path.basename(input).split("-")[2].split(".")[0]
-    
+
     error_level = 0
-    error_colors = dict({0:'green', 1:'orange', 2:'red', 3:'red'})
+    error_colors = dict({0:'green', 1:'orange', 2:'red', 3:'black'})
 
     lines = []
     f = open(input, "rb")
@@ -224,12 +224,12 @@ def write_logfile_html(input, output, night):
             error_level = max(error_level, 3)
 
         lines.append(line)
-        
-    html_components = dict(        
+
+    html_components = dict(
         bokeh_version=bokeh.__version__, log=True, logfile=lines, file_url=output,
         basename=os.path.splitext(os.path.basename(input))[0], night=night,
         available=available, current=current, expid=int(str(expid)), zexpid=expid,
-        num_dirs=2, qatype='summary', error_level=error_level, 
+        num_dirs=2, qatype='summary', error_level=error_level,
         error_color=error_colors.get(error_level),
     )
 
@@ -238,7 +238,7 @@ def write_logfile_html(input, output, night):
     #- Write HTML text to the output file
     with open(output, 'w') as fx:
         fx.write(html)
-    
+
     print('Wrote {}'.format(output))
-    
+
     return error_colors.get(error_level)

--- a/py/qqa/webpages/summary.py
+++ b/py/qqa/webpages/summary.py
@@ -157,11 +157,11 @@ def write_logtable_html(outfile, logdir, night, expid, error_colors=dict(), qpro
     logfiles = [i for i in os.listdir(logdir) if re.match(r'.*\.log', i)]
     for file in logfiles:
         available += [file.split("-")[1]]
-
-    #- TODO: delete
-    print('debugging in summary.py, line 162')
-    import IPython
-    IPython.embed()
+    
+    #- Shows all failed qprocs as red
+    for qfail in qproc_fails:
+        qfail = qfail.split("-")[1]
+        error_colors[qfail] = 'red'
     
     html_components = dict(
         version=bokeh.__version__, logfile=True, night=night, available=available,
@@ -205,7 +205,7 @@ def write_logfile_html(input, output, night):
     expid = os.path.basename(input).split("-")[2].split(".")[0]
     
     error_level = 0
-    error_colors = dict({1:'orange', 2:'orangered', 3:'red'})
+    error_colors = dict({1:'orange', 2:'pink', 3:'red'})
 
     lines = []
     f = open(input, "rb")

--- a/py/qqa/webpages/summary.py
+++ b/py/qqa/webpages/summary.py
@@ -164,10 +164,6 @@ def write_logtable_html(outfile, logdir, night, expid, available=None, error_col
     for qfail in qproc_fails:
         error_colors[qfail] = 'red'
     
-#     for log_cam in available:
-#         if log_cam not in error_colors:
-#             error_colors[log_cam] = 'green'
-    
     html_components = dict(
         version=bokeh.__version__, logfile=True, night=night, available=available,
         current=None, expid=int(expid), zexpid='{:08d}'.format(expid),

--- a/py/qqa/webpages/summary.py
+++ b/py/qqa/webpages/summary.py
@@ -129,7 +129,8 @@ def write_summary_html(outfile, qadata, qprocdir):
 
 
 
-def write_logtable_html(outfile, logdir, night, expid, error_colors=dict(), qproc_fails=[]):
+def write_logtable_html(outfile, logdir, night, expid, available=None, error_colors=dict(), 
+                        qproc_fails=[]):
     """Write a table of logfiles to outfile
 
     Args:
@@ -152,16 +153,20 @@ def write_logtable_html(outfile, logdir, night, expid, error_colors=dict(), qpro
     if not logdir:
         logdir = ''
     
-    available = []
+    if available==None:
+        available = []
     
-    logfiles = [i for i in os.listdir(logdir) if re.match(r'.*\.log', i)]
-    for file in logfiles:
-        available += [file.split("-")[1]]
-    
+        logfiles = [i for i in os.listdir(logdir) if re.match(r'.*\.log', i)]
+        for file in logfiles:
+            available += [file.split("-")[1]]
+
     #- Shows all failed qprocs as red
     for qfail in qproc_fails:
-        qfail = qfail.split("-")[1]
         error_colors[qfail] = 'red'
+    
+#     for log_cam in available:
+#         if log_cam not in error_colors:
+#             error_colors[log_cam] = 'green'
     
     html_components = dict(
         version=bokeh.__version__, logfile=True, night=night, available=available,
@@ -205,7 +210,7 @@ def write_logfile_html(input, output, night):
     expid = os.path.basename(input).split("-")[2].split(".")[0]
     
     error_level = 0
-    error_colors = dict({1:'orange', 2:'pink', 3:'red'})
+    error_colors = dict({0:'green', 1:'orange', 2:'pink', 3:'red'})
 
     lines = []
     f = open(input, "rb")
@@ -218,10 +223,10 @@ def write_logfile_html(input, output, night):
         elif 'ERROR' in line:
             line = '<span style="color:{};">'.format(error_colors.get(2)) + line + '</span>'
             error_level = max(error_level, 2)
-        elif 'CRITICAL' in line or 'FATAL' in line:
+        elif 'CRITICAL' in line or 'FATAL' in line or 'Traceback' in line:
             line = '<span style="color:{};">'.format(error_colors.get(3)) + line + '</span>'
             error_level = max(error_level, 3)
-        
+
         lines.append(line)
         
     html_components = dict(        

--- a/py/qqa/webpages/tables.py
+++ b/py/qqa/webpages/tables.py
@@ -217,7 +217,9 @@ def write_exposures_tables(indir, outdir, exposures, nights=None):
                     short_name = qatype.split("_")[1].lower()
 
                     expinfo[qatype] = qastatus.name
-            
+                    if qatype != 'QPROC':
+                        expinfo[qatype + "_link"] = '{expid:08d}/qa-{name}-{expid:08d}.html'.format(expid=expid, name=short_name)            
+
             explist.append(expinfo)
 
         html = template.render(night=night, exposures=explist, autoreload=True,

--- a/py/qqa/webpages/tables.py
+++ b/py/qqa/webpages/tables.py
@@ -144,7 +144,7 @@ get_explinks({})
 
             
 
-def write_exposures_tables(indir,outdir, exposures, nights=None, qproc_fails=None):
+def write_exposures_tables(indir,outdir, exposures, nights=None):
     """
     outfile: output HTML files to outdir/YEARMMDD/exposures.html
     exposures: table with columns NIGHT, EXPID
@@ -196,14 +196,16 @@ def write_exposures_tables(indir,outdir, exposures, nights=None, qproc_fails=Non
                     expinfo[qatype] = qastatus.name
                     expinfo[qatype + "_link"] = '{expid:08d}/qa-{name}-{expid:08d}.html'.format(
                         expid=expid, name=short_name)
+            
+            
             #- Adds qproc to the expid status
-            if qproc_fails is None:
-                expinfo['QPROC'] = '-'
+            #- TODO: add some catches to this for robustness, e.g. the '-' if QPROC is missing
+            qproc_fails = exposures[ii][exposures[ii]['EXPID']==expid]['QPROC'][0]
+            if qproc_fails == 0:
+                expinfo['QPROC'] = 'ok'
             else:
-                if len(qproc_fails) == 0:
-                    expinfo['QPROC'] = 'ok'
-                else:
-                    expinfo['QPROC'] = 'error'
+                expinfo['QPROC'] = 'error'
+
             expinfo['QPROC_link'] = '{expid:08d}/qa-summary-{expid:08d}-logfiles_table.html'.format(expid=expid)
 
             explist.append(expinfo)

--- a/py/qqa/webpages/tables.py
+++ b/py/qqa/webpages/tables.py
@@ -144,12 +144,14 @@ get_explinks({})
 
             
 
-def write_exposures_tables(indir,outdir, exposures, nights=None):
+def write_exposures_tables(indir,outdir, exposures, nights=None, qproc_fails=[]):
     """
     outfile: output HTML files to outdir/YEARMMDD/exposures.html
     exposures: table with columns NIGHT, EXPID
     nights: optional list of nights to process
     """
+    import IPython
+    IPython.embed()
 
     env = jinja2.Environment(
         loader=jinja2.PackageLoader('qqa.webpages', 'templates')

--- a/py/qqa/webpages/tables.py
+++ b/py/qqa/webpages/tables.py
@@ -144,14 +144,12 @@ get_explinks({})
 
             
 
-def write_exposures_tables(indir,outdir, exposures, nights=None, qproc_fails=[]):
+def write_exposures_tables(indir,outdir, exposures, nights=None, qproc_fails=None):
     """
     outfile: output HTML files to outdir/YEARMMDD/exposures.html
     exposures: table with columns NIGHT, EXPID
     nights: optional list of nights to process
     """
-    import IPython
-    IPython.embed()
 
     env = jinja2.Environment(
         loader=jinja2.PackageLoader('qqa.webpages', 'templates')
@@ -196,7 +194,17 @@ def write_exposures_tables(indir,outdir, exposures, nights=None, qproc_fails=[])
                     short_name = qatype.split("_")[1].lower()
 
                     expinfo[qatype] = qastatus.name
-                    expinfo[qatype + "_link"] = '{expid:08d}/qa-{name}-{expid:08d}.html'.format(expid=expid, name=short_name)
+                    expinfo[qatype + "_link"] = '{expid:08d}/qa-{name}-{expid:08d}.html'.format(
+                        expid=expid, name=short_name)
+            #- Adds qproc to the expid status
+            if qproc_fails is None:
+                expinfo['QPROC'] = '-'
+            else:
+                if len(qproc_fails) == 0:
+                    expinfo['QPROC'] = 'ok'
+                else:
+                    expinfo['QPROC'] = 'error'
+            expinfo['QPROC_link'] = '{expid:08d}/qa-summary-{expid:08d}-logfiles_table.html'.format(expid=expid)
 
             explist.append(expinfo)
 

--- a/py/qqa/webpages/templates/exposures.html
+++ b/py/qqa/webpages/templates/exposures.html
@@ -59,7 +59,7 @@
 {% if exp.fail == 1 %}
     <td style="color:red">{{ exp.night }}</td>
     <td style="color:red">{{ exp.expid }}</td>
-    <td colspan="11">Failed to process</td>
+    <td colspan="12">Failed to process</td>
 {% else %}
     <td>{{ exp.night }}</td>
     <td><a href="{{ exp.link }}">{{ exp.expid }}</a></td>

--- a/py/qqa/webpages/templates/exposures.html
+++ b/py/qqa/webpages/templates/exposures.html
@@ -38,13 +38,14 @@
 <table>
 <tr>
   <th colspan="5">Metadata</th>
-  <th colspan="6">QA Status</th>
+  <th colspan="7">QA Status</th>
 <tr>
   <th>NIGHT</th>
   <th>EXPID</th>
   <th>FLAVOR</th>
   <th>EXPTIME</th>
   <th>SPECTROS</th>
+  <th>Qproc</th>
   <th>Amp</th>
   <th>Camera</th>
   <th>Fiber</th>
@@ -60,6 +61,12 @@
   <td>{{ exp.flavor }}</td>
   <td>{{ exp.exptime }}</td>
   <td>{{ exp.spectros }}</td>
+
+{% if exp.QPROC_LINK != "na" %}
+  <td><a href="{{ exp.QPROC_link }}">{{ exp.QPROC }}</a></td>
+{% else %}
+  <td>{{ exp.QPROC }}</td>
+{% endif %}
 
 {% if exp.PER_AMP_link != "na" %}
   <td><a href="{{ exp.PER_AMP_link }}">{{ exp.PER_AMP }}</a></td>

--- a/py/qqa/webpages/templates/logfile.html
+++ b/py/qqa/webpages/templates/logfile.html
@@ -74,15 +74,15 @@ table {
 
       {% if not current %}
       <font size="6" color={{error_colors.get(c+i)}} >
-      {% endif %}
       {% if error_colors.get(c+i) == 'black'%}
       <mark>
       {% endif %}
+      {% endif %}
         <text {% if c + i in available %} style="font-weight:bold;"{% endif %}>{{c}}{{i}}<text>
+      {% if not current %}
       {% if error_colors.get(c+i) == 'black'%}
       </mark>
       {% endif %}
-      {% if not current %}
       </font>
       {% endif %}
 

--- a/py/qqa/webpages/templates/logfile.html
+++ b/py/qqa/webpages/templates/logfile.html
@@ -71,11 +71,17 @@ table {
       {% if (c+i != current) and (c+i in available) %}
     <a href="qproc-{{c}}{{i}}-{{zexpid}}-logfile.html">
       {% endif %}
-      
+
       {% if not current %}
       <font size="6" color={{error_colors.get(c+i)}} >
       {% endif %}
+      {% if error_colors.get(c+i) == 'black'%}
+      <mark>
+      {% endif %}
         <text {% if c + i in available %} style="font-weight:bold;"{% endif %}>{{c}}{{i}}<text>
+      {% if error_colors.get(c+i) == 'black'%}
+      </mark>
+      {% endif %}
       {% if not current %}
       </font>
       {% endif %}

--- a/py/qqa/webpages/templates/logfile.html
+++ b/py/qqa/webpages/templates/logfile.html
@@ -73,10 +73,7 @@ table {
       {% endif %}
       
       {% if not current %}
-      <font size="6" 
-            {% if c + i in error_colors %} color={{error_colors.get(c+i)}} 
-            {% else %} color="green"
-            {% endif %}>
+      <font size="6" color={{error_colors.get(c+i)}} >
       {% endif %}
         <text {% if c + i in available %} style="font-weight:bold;"{% endif %}>{{c}}{{i}}<text>
       {% if not current %}

--- a/py/qqa/webpages/templates/qabase.html
+++ b/py/qqa/webpages/templates/qabase.html
@@ -62,6 +62,10 @@ function get_explinks(links) {
         "../../../../../../"+next_item.night+"/"+next_item.zexpid+"/spectra/{{view}}/{{frame}}/{{downsample}}x/".toLowerCase();;
         {% elif input and not spectra %}
         "../../../../"+next_item.night+"/"+next_item.zexpid+"/spectra/input/";
+        {% elif logfile and current %}
+          "../../"+next_item.night+"/"+next_item.zexpid+"/qproc-{{current}}-"+next_item.zexpid+"-logfile.html";
+        {% elif logfile and not current %}
+          "../../"+next_item.night+"/"+next_item.zexpid+"/qa-summary-"+next_item.zexpid+"-logfiles_table.html";
         {% else %}
           "../../"+next_item.night+"/"+next_item.zexpid+"/qa-{{ qatype }}-"+next_item.zexpid+".html";
         {% endif %}

--- a/py/qqa/webpages/templates/qabase.html
+++ b/py/qqa/webpages/templates/qabase.html
@@ -62,9 +62,7 @@ function get_explinks(links) {
         "../../../../../../"+next_item.night+"/"+next_item.zexpid+"/spectra/{{view}}/{{frame}}/{{downsample}}x/".toLowerCase();;
         {% elif input and not spectra %}
         "../../../../"+next_item.night+"/"+next_item.zexpid+"/spectra/input/";
-        {% elif logfile and current %}
-          "../../"+next_item.night+"/"+next_item.zexpid+"/qproc-{{current}}-"+next_item.zexpid+"-logfile.html";
-        {% elif logfile and not current %}
+        {% elif logfile %}
           "../../"+next_item.night+"/"+next_item.zexpid+"/qa-summary-"+next_item.zexpid+"-logfiles_table.html";
         {% else %}
           "../../"+next_item.night+"/"+next_item.zexpid+"/qa-{{ qatype }}-"+next_item.zexpid+".html";
@@ -84,9 +82,7 @@ function get_explinks(links) {
         "../../../../../../"+prev_item.night+"/"+prev_item.zexpid+"/spectra/{{view}}/{{frame}}/{{downsample}}x/".toLowerCase();;
         {% elif input and not spectra %}
         "../../../../"+prev_item.night+"/"+prev_item.zexpid+"/spectra/input/";
-        {% elif logfile and current %}
-          "../../"+prev_item.night+"/"+prev_item.zexpid+"/qproc-{{current}}-"+prev_item.zexpid+"-logfile.html";
-        {% elif logfile and not current %}
+        {% elif logfile %}
           "../../"+prev_item.night+"/"+prev_item.zexpid+"/qa-summary-"+prev_item.zexpid+"-logfiles_table.html";
         {% else %}
           "../../"+prev_item.night+"/"+prev_item.zexpid+"/qa-{{ qatype }}-"+prev_item.zexpid+".html";

--- a/py/qqa/webpages/templates/qabase.html
+++ b/py/qqa/webpages/templates/qabase.html
@@ -84,6 +84,10 @@ function get_explinks(links) {
         "../../../../../../"+prev_item.night+"/"+prev_item.zexpid+"/spectra/{{view}}/{{frame}}/{{downsample}}x/".toLowerCase();;
         {% elif input and not spectra %}
         "../../../../"+prev_item.night+"/"+prev_item.zexpid+"/spectra/input/";
+        {% elif logfile and current %}
+          "../../"+prev_item.night+"/"+prev_item.zexpid+"/qproc-{{current}}-"+prev_item.zexpid+"-logfile.html";
+        {% elif logfile and not current %}
+          "../../"+prev_item.night+"/"+prev_item.zexpid+"/qa-summary-"+prev_item.zexpid+"-logfiles_table.html";
         {% else %}
           "../../"+prev_item.night+"/"+prev_item.zexpid+"/qa-{{ qatype }}-"+prev_item.zexpid+".html";
         {% endif %}

--- a/py/qqa/wrap_qproc.py
+++ b/py/qqa/wrap_qproc.py
@@ -8,6 +8,7 @@ def run(options=None):
     parser.add_argument("--outdir", type=str, required=True, 
                         help="output directory (without appending YEARMMDD/EXPID/)")
     parser.add_argument("--cameras", type=str, help="comma separated list of cameras (for debugging)")
+    parser.add_argument("--qfails", type=str, help="empty list to store failed qprocesses")
 
     if options is None:
         options = sys.argv[2:]
@@ -18,9 +19,13 @@ def run(options=None):
         cameras = args.cameras.split(',')
     else:
         cameras = None
+    
+    if args.qfails:
+        qfails = args.qfails.split(',')
+    else:
+        qfails=[]
 
-
-    run_qproc(args.rawfile, args.outdir, cameras=cameras)
+    run_qproc(args.rawfile, args.outdir, cameras=cameras, qproc_fails=qfails)
 
 if __name__ == '__main__':   
     run()

--- a/py/qqa/wrap_qproc.py
+++ b/py/qqa/wrap_qproc.py
@@ -8,7 +8,6 @@ def run(options=None):
     parser.add_argument("--outdir", type=str, required=True, 
                         help="output directory (without appending YEARMMDD/EXPID/)")
     parser.add_argument("--cameras", type=str, help="comma separated list of cameras (for debugging)")
-    parser.add_argument("--qfails", type=str, help="empty list to store failed qprocesses")
 
     if options is None:
         options = sys.argv[2:]
@@ -20,12 +19,7 @@ def run(options=None):
     else:
         cameras = None
     
-    if args.qfails:
-        qfails = args.qfails.split(',')
-    else:
-        qfails=[]
-
-    run_qproc(args.rawfile, args.outdir, cameras=cameras, qproc_fails=qfails)
+    run_qproc(args.rawfile, args.outdir, cameras=cameras)
 
 if __name__ == '__main__':   
     run()


### PR DESCRIPTION
Addresses #94 and #95 by tracking qproc fails

A little ugly, maybe needs refactoring: current solution is to add a mutated argument of a list which appends any failed qprocs throughout the monitor --> plots pipeline
notes:
- builds off of #100 so merge that first
- only works on serial qprocs
- TODO: needs to work on parallelized qprocs, check that it works for qprocs spawned to batch processes

other edits:
- improves color range for greater visual distinction
- adds column to exposures table called Qproc which indicates if any qprocs failed, links to the summary-logfiles_table page