### PR TITLE
Track failed exps

### DIFF
--- a/py/qqa/run.py
+++ b/py/qqa/run.py
@@ -412,7 +412,7 @@ def make_plots(infile, basedir, preprocdir=None, logdir=None, cameras=None):
         web_summary.write_logtable_html(htmlfile, logdir, night, expid, error_colors)
 
 
-def write_tables(indir, outdir, failed_exps=list()):
+def write_tables(indir, outdir):
     '''TODO: document
     Parses directory for available nights, exposures to generate
     nights and exposures tables
@@ -420,9 +420,6 @@ def write_tables(indir, outdir, failed_exps=list()):
     Args:
         indir : directory of nights
         outdir : directory where to write nights table 
-    Options:
-        failed_exps : list of dict(NIGHT, EXPID, FAIL=1) elements corresponding
-                      to failed exposures, only supported for qqa monitor processing
     '''
     import re
     from astropy.table import Table
@@ -447,18 +444,14 @@ def write_tables(indir, outdir, failed_exps=list()):
                         rows.append(dict(NIGHT=night, EXPID=expid, FAIL=0))
                     else:
                         log.error('Missing {}'.format(qafile))
+                        rows.append(dict(NIGHT=night, EXPID=expid, FAIL=1))
 
     if len(rows) == 0:
         msg = "No exp dirs found in {}/NIGHT/EXPID".format(indir)
         raise RuntimeError(msg)
 
     exposures = Table(rows)
-    #- vertically stack the existing exposures and the failed exposures
-    if len(failed_exps) > 0:
-        from astropy.table import vstack
-        failed_exposures = Table(failed_exps)
-        exposures = vstack([exposures, failed_exposures], join_type='outer')
-        
+    
     caldir = os.path.join(outdir, 'cal_files')
     if not os.path.isdir(caldir):
         os.makedirs(caldir)

--- a/py/qqa/script.py
+++ b/py/qqa/script.py
@@ -89,7 +89,6 @@ def main_monitor(options=None):
 
     qarunner = QARunner()
     processed = set()
-    failed_exposures = list() #- to track failed exposures
 
     #- TODO: figure out a way to print how many nights are being skipped before startdate
     while True:        
@@ -174,7 +173,7 @@ def main_monitor(options=None):
                 run.make_plots(infile=qafile, basedir=args.plotdir, preprocdir=outdir, logdir=outdir,
                                cameras=cameras)
 
-                run.write_tables(args.outdir, args.plotdir, failed_exps=failed_exposures)
+                run.write_tables(args.outdir, args.plotdir)
 
                 time_end = time.time()
                 dt = (time_end - time_start) / 60
@@ -182,12 +181,6 @@ def main_monitor(options=None):
                     time.strftime('%H:%M'), night, expid, dt))
 
             except Exception as e :
-                #- only adds failed exposure to list if no qa file found
-                if not qafile:
-                    qafile = "{}/qa-{}.fits".format(outdir,expid)
-                if not os.path.exists(qafile):
-                    failed_exposures.append(dict(NIGHT=int(night), EXPID=int(expid), FAIL=1))                
-                
                 print("Failed to process or QA or plot exposure {}".format(expid))
                 print("Error message: {}".format(str(e)))
                 exc_info = sys.exc_info()

--- a/py/qqa/script.py
+++ b/py/qqa/script.py
@@ -89,9 +89,10 @@ def main_monitor(options=None):
 
     qarunner = QARunner()
     processed = set()
+    failed_exposures = list() #- to track failed exposures
 
     #- TODO: figure out a way to print how many nights are being skipped before startdate
-    while True:
+    while True:        
         if args.catchup:
             expdir = run.find_unprocessed_expdir(args.indir, args.outdir, processed, startdate=args.startdate)
         else:
@@ -173,7 +174,7 @@ def main_monitor(options=None):
                 run.make_plots(infile=qafile, basedir=args.plotdir, preprocdir=outdir, logdir=outdir,
                                cameras=cameras)
 
-                run.write_tables(args.outdir, args.plotdir)
+                run.write_tables(args.outdir, args.plotdir, failed_exps=failed_exposures)
 
                 time_end = time.time()
                 dt = (time_end - time_start) / 60
@@ -181,12 +182,19 @@ def main_monitor(options=None):
                     time.strftime('%H:%M'), night, expid, dt))
 
             except Exception as e :
+                #- only adds failed exposure to list if no qa file found
+                if not qafile:
+                    qafile = "{}/qa-{}.fits".format(outdir,expid)
+                if not os.path.exists(qafile):
+                    failed_exposures.append(dict(NIGHT=int(night), EXPID=int(expid), FAIL=1))                
+                
                 print("Failed to process or QA or plot exposure {}".format(expid))
                 print("Error message: {}".format(str(e)))
                 exc_info = sys.exc_info()
                 traceback.print_exception(*exc_info)
                 del exc_info
                 print("Now moving on ...")
+                
 
             processed.add(expdir)
 

--- a/py/qqa/webpages/templates/exposures.html
+++ b/py/qqa/webpages/templates/exposures.html
@@ -55,48 +55,55 @@
 
 {% for exp in exposures|reverse %}
 <tr>
-  <td>{{ exp.night }}</td>
-  <td><a href="{{ exp.link }}">{{ exp.expid }}</a></td>
-  <td>{{ exp.flavor }}</td>
-  <td>{{ exp.exptime }}</td>
-  <td>{{ exp.spectros }}</td>
-
-{% if exp.PER_AMP_link != "na" %}
-  <td><a href="{{ exp.PER_AMP_link }}">{{ exp.PER_AMP }}</a></td>
+{% if exp.fail == 1 %}
+    <td style="color:red">{{ exp.night }}</td>
+    <td style="color:red">{{ exp.expid }}</td>
+    <td colspan="11">Failed to process</td>
 {% else %}
-  <td>{{ exp.PER_AMP }}</td>
-{% endif %}
+    <td>{{ exp.night }}</td>
+    <td><a href="{{ exp.link }}">{{ exp.expid }}</a></td>
+    <td>{{ exp.flavor }}</td>
+    <td>{{ exp.exptime }}</td>
+    <td>{{ exp.spectros }}</td>
 
-{% if exp.PER_CAMERA_link != "na" %}
-  <td><a href="{{ exp.PER_CAMERA_link }}">{{ exp.PER_CAMERA }}</a></td>
-{% else %}
-  <td>{{ exp.PER_CAMERA }}</td>
-{% endif %}
+    {% if exp.PER_AMP_link != "na" %}
+      <td><a href="{{ exp.PER_AMP_link }}">{{ exp.PER_AMP }}</a></td>
+    {% else %}
+      <td>{{ exp.PER_AMP }}</td>
+    {% endif %}
 
-{% if exp.PER_FIBER_link != "na" %}
-  <td><a href="{{ exp.PER_FIBER_link }}">{{ exp.PER_FIBER }}</a></td>
-{% else %}
-  <td>{{ exp.PER_FIBER }}</td>
-{% endif %}
+    {% if exp.PER_CAMERA_link != "na" %}
+      <td><a href="{{ exp.PER_CAMERA_link }}">{{ exp.PER_CAMERA }}</a></td>
+    {% else %}
+      <td>{{ exp.PER_CAMERA }}</td>
+    {% endif %}
 
-{% if exp.PER_CAMFIBER_link != "na" %}
-  <td><a href="{{ exp.PER_CAMFIBER_link }}">{{ exp.PER_CAMFIBER }}</a></td>
-{% else %}
-  <td>{{ exp.PER_CAMFIBER }}</td>
-{% endif %}
+    {% if exp.PER_FIBER_link != "na" %}
+      <td><a href="{{ exp.PER_FIBER_link }}">{{ exp.PER_FIBER }}</a></td>
+    {% else %}
+      <td>{{ exp.PER_FIBER }}</td>
+    {% endif %}
 
-{% if exp.PER_SPECTRO_link != "na" %}
-  <td><a href="{{ exp.PER_SPECTRO_link }}">{{ exp.PER_SPECTRO }}</a></td>
-{% else %}
-  <td>{{ exp.PER_SPECTRO }}</td>
-{% endif %}
+    {% if exp.PER_CAMFIBER_link != "na" %}
+      <td><a href="{{ exp.PER_CAMFIBER_link }}">{{ exp.PER_CAMFIBER }}</a></td>
+    {% else %}
+      <td>{{ exp.PER_CAMFIBER }}</td>
+    {% endif %}
 
-{% if exp.PER_EXP_link != "na" %}
-  <td><a href="{{ exp.PER_EXP_link }}">{{ exp.PER_EXP }}</a></td>
-{% else %}
-  <td>{{ exp.PER_EXP }}</td>
-{% endif %}
+    {% if exp.PER_SPECTRO_link != "na" %}
+      <td><a href="{{ exp.PER_SPECTRO_link }}">{{ exp.PER_SPECTRO }}</a></td>
+    {% else %}
+      <td>{{ exp.PER_SPECTRO }}</td>
+    {% endif %}
 
+    {% if exp.PER_EXP_link != "na" %}
+      <td><a href="{{ exp.PER_EXP_link }}">{{ exp.PER_EXP }}</a></td>
+    {% else %}
+      <td>{{ exp.PER_EXP }}</td>
+    {% endif %}
+
+{% endif %}
+    
 </tr>
 {% endfor %}
 


### PR DESCRIPTION
While writing the exposures tables, checks for any exposures that don't have a qa fits file (i.e. missing) and adds them to the table as a failed exposure

Addressing #102 request @julienguy 